### PR TITLE
LPS-77952 increase z-index of .lfr-alert-container to display over Ad…

### DIFF
--- a/modules/apps/foundation/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/taglib/_alert.scss
+++ b/modules/apps/foundation/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/taglib/_alert.scss
@@ -4,7 +4,7 @@
 	right: auto;
 	top: auto;
 	width: 100%;
-	z-index: 430;
+	z-index: 960;
 
 	&.inline-alert-container {
 		position: relative;


### PR DESCRIPTION
…d button

Alert container would be behind the Add button and made it impossible to get rid of container message.

I increased the z-index of .lfr-alert-container enough so that the container would be in front of the Add button but not enough so that it would interfere with other components. I have tested this fix and have seen no regressions during my tests.
This fix would also solve https://issues.liferay.com/browse/LPS-77908 since it is the same issue.

Another solution would be to decrease the z-index of .btn-action, .btn-action-secondary. I have not tested this solution so I am not sure if there would be any regressions if this solution were to be implemented.

Any questions or comments let me know.
Thank you!