### PR TITLE
LPS-66825 Keep trying to redirect until it is successful

### DIFF
--- a/modules/apps/foundation/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/session.js
+++ b/modules/apps/foundation/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/session.js
@@ -189,6 +189,16 @@ AUI.add(
 											if (instance.get('redirectOnExpire')) {
 												location.href = instance.get('redirectUrl');
 											}
+										},
+										failure: function(event, id, obj) {
+											instance._expireIO = null;
+
+											A.setTimeout(
+												function() {
+													instance._getExpireIO().start();
+												},
+												1000
+											);
 										}
 									}
 								}


### PR DESCRIPTION
Putting the computer in Sleep mode and allowing the session to expire does not redirect the user.

An SDH for this issue was created but never committed, LPE-15143. I added the fix and it redirects the user to the main page when waking the computer.

Any questions or comments let me know.
Thank you!