### PR TITLE
LPS-78048 Fix Plus Button Size in Data Providers

### DIFF
--- a/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-data-provider-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-data-provider-web/src/main/resources/META-INF/resources/css/main.scss
@@ -2,9 +2,9 @@
 
 .portlet-dynamic-data-mapping-data-provider {
 	.btn-action {
-		height: 64px;
-		line-height: 60px;
-		width: 64px;
+		height: 2.1rem;
+		line-height: 2.1rem;
+		width: 2.1rem;
 	}
 
 	.form {


### PR DESCRIPTION
Hello @gregory-bretall ,

https://issues.liferay.com/browse/LPS-78048

Current Add Button size in Data Providers is excessively large.
This is a simple fix that makes the button size a bit smaller and also keep it consistent with how other modules determine the size of their add buttons.

If you have any questions, please let me know. Thanks.

Sincerely,
Brian Kim