### PR TITLE
LPS-78048 Removed Outdated CSS Conforming to Old UI Patterns in Data …

### DIFF
--- a/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-data-provider-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-data-provider-web/src/main/resources/META-INF/resources/css/main.scss
@@ -1,15 +1,7 @@
 @import "mixins";
 
 .portlet-dynamic-data-mapping-data-provider {
-	.btn-action {
-		height: 64px;
-		line-height: 60px;
-		width: 64px;
-	}
-
 	.form {
-		padding: 0 20px;
-
 		.help-block {
 			position: absolute;
 		}


### PR DESCRIPTION
Hello @gregory-bretall  ,

https://issues.liferay.com/browse/LPS-78048

Current Add Button size in Data Providers is excessively large.

The reason this issue occurs is because,  in https://issues.liferay.com/browse/LPS-77325 (commit a96e7068177939081a6dd44217aa5d4096c0910c), CSS for .btn-action was added in 

https://github.com/liferay/liferay-portal/blob/master/modules/apps/foundation/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/compat/components/_management_bar.scss#L15

However, the CSS for .btn-action in modules\apps\forms-and-workflow\dynamic-data-mapping\dynamic-data-mapping-data-provider-web\src\main\resources\META-INF\resources\css\main.scss was overriding the one that exists in _management_bar.scss because  main.scss is loaded after _management_bar.scss.

I have confirmed that removing .btn-action for main.scss in dynamic-data-mapping-data-provider-web enables the .btn-action in _management_bar.scss to take effect. I have also confirmed that removing the CSS does not cause any inconsistencies or unintended changes in Forms.

If you have any questions, please let me know. Thanks.

Sincerely,
Brian Kim