### PR TITLE
LPS-78109 Remove Faulty cssClass for Shopping Kebab Menu

### DIFF
--- a/modules/apps/shopping/shopping-web/src/main/resources/META-INF/resources/categories.jsp
+++ b/modules/apps/shopping/shopping-web/src/main/resources/META-INF/resources/categories.jsp
@@ -270,7 +270,6 @@ boolean showSearch = (categoriesAndItemsCount > 0);
 					</liferay-ui:search-container-column-text>
 
 					<liferay-ui:search-container-column-jsp
-						cssClass="list-group-item-field"
 						path="/item_action.jsp"
 					/>
 				</c:when>
@@ -329,7 +328,6 @@ boolean showSearch = (categoriesAndItemsCount > 0);
 					</liferay-ui:search-container-column-text>
 
 					<liferay-ui:search-container-column-jsp
-						cssClass="list-group-item-field"
 						path="/category_action.jsp"
 					/>
 				</c:when>


### PR DESCRIPTION
Hello @gregory-bretall ,

https://issues.liferay.com/browse/LPS-78109

The issue here is that the Kebab menu position in categories section for the Shopping Portlet is misplaced because it is using an unnecessary cssClass.

If you wish to be thorough in checking, the fix applies changes to both categories and items.

The fix was to remove the cssClass.

Please let me know if you have any questions. Thanks.

Sincerely,
Brian Kim