### PR TITLE
LPS-78221 Created counter to keep track of open and close tags for co…

### DIFF
--- a/modules/apps/foundation/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/xml_formatter.js
+++ b/modules/apps/foundation/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/xml_formatter.js
@@ -68,6 +68,8 @@ AUI.add(
 						content = content.replace(REGEX_TAG_OPEN, STR_TOKEN + '<');
 						content = content.replace(REGEX_NAMESPACE_XML_ATTR, STR_TOKEN + '$1$2');
 
+						var commentCounter = 0;
+
 						var items = content.split(STR_TOKEN);
 
 						var inComment = false;
@@ -81,16 +83,25 @@ AUI.add(
 								if (REGEX_DECLARATIVE_OPEN.test(item)) {
 									result += instance._indent(lineIndent, tagIndent, level) + item;
 
+									commentCounter++;
 									inComment = true;
 
 									if (REGEX_DECLARATIVE_CLOSE.test(item) || REGEX_DOCTYPE.test(item)) {
-										inComment = false;
+										commentCounter--;
+
+										if (commentCounter == 0) {
+											inComment = false;
+										}
 									}
 								}
 								else if (REGEX_DECLARATIVE_CLOSE.test(item)) {
 									result += item;
 
-									inComment = false;
+									commentCounter--;
+
+									if (commentCounter == 0) {
+										inComment = false;
+									}
 								}
 								else if (REGEX_ELEMENT.exec(items[index - 1]) && REGEX_ELEMENT_CLOSE.exec(item) &&
 									REGEX_ELEMENT_NAMESPACED.exec(items[index - 1]) == REGEX_ELEMENT_NAMESPACED_CLOSE.exec(item)[0].replace('/', STR_BLANK)) {


### PR DESCRIPTION
…mments

When a freemarker template contains comments and if statements, the end tags of the if statement will throw off the xml_formatter causing an array index error.

To fix this, I added a counter for the comments. This way it will check for the amount of open and close comment tags.