### PR TITLE
Lps 78294 Fix Special Character Inconsistency in Documents and Media

### DIFF
--- a/modules/apps/collaboration/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_shortcut.jsp
+++ b/modules/apps/collaboration/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_shortcut.jsp
@@ -109,7 +109,7 @@ if (portletTitleBasedNavigation) {
 				String toGroupName = StringPool.BLANK;
 
 				if (toGroup != null) {
-					toGroupName = HtmlUtil.escape(toGroup.getDescriptiveName(locale));
+					toGroupName = toGroup.getDescriptiveName(locale);
 				}
 				%>
 
@@ -120,7 +120,7 @@ if (portletTitleBasedNavigation) {
 				</div>
 
 				<%
-				String toFileEntryTitle = BeanPropertiesUtil.getString(toFileEntry, "title");
+				String toFileEntryTitle = HtmlUtil.unescape(BeanPropertiesUtil.getString(toFileEntry, "title"));
 				%>
 
 				<div class="form-group">

--- a/modules/apps/collaboration/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/select_file_entry.jsp
+++ b/modules/apps/collaboration/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/select_file_entry.jsp
@@ -106,7 +106,7 @@ dlSearchContainer.setResults(foldersAndFileEntriesAndFileShortcuts);
 								%>
 
 								<aui:a cssClass="selector-button" data="<%= data %>" href="javascript:;">
-									<%= HtmlUtil.escape(fileEntry.getTitle()) %>
+									<%= fileEntry.getTitle() %>
 								</aui:a>
 
 								<c:if test="<%= Validator.isNotNull(fileEntry.getDescription()) %>">


### PR DESCRIPTION
Hello @gregory-bretall ,

https://issues.liferay.com/browse/LPS-78294

The issue is that special characters (ampersand) are not being correctly displayed specifically when you try to edit file shortcuts for basic documents that have special characters and sites with special characters.

The reason the fix has to be made in Select_File_Entry and Edit_File_Shortcut is because when you try to edit a shortcut, you have to also choose a document for the shortcut to be based on. Select_File_Entry is called in this process, but it also has incorrect implementation.

If you have any questions, please let me know. Thanks.

Sincerely,
Brian Kim