### PR TITLE
LPS-78467 Fix Asset Publisher Configuration to Allow Page Scopes

### DIFF
--- a/modules/apps/web-experience/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/display/context/LayoutScopesItemSelectorViewDisplayContext.java
+++ b/modules/apps/web-experience/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/display/context/LayoutScopesItemSelectorViewDisplayContext.java
@@ -45,6 +45,8 @@ public class LayoutScopesItemSelectorViewDisplayContext
 		super(
 			request, siteItemSelectorCriterion, itemSelectedEventName,
 			portletURL);
+
+		_scopeGroupId = getGroupId();
 	}
 
 	@Override
@@ -52,16 +54,20 @@ public class LayoutScopesItemSelectorViewDisplayContext
 		ThemeDisplay themeDisplay = (ThemeDisplay)request.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
+		if (_scopeGroupId <= 0) {
+			_scopeGroupId = themeDisplay.getScopeGroupId();
+		}
+
 		GroupSearch groupSearch = new GroupSearch(
 			getPortletRequest(), getPortletURL());
 
 		int total = GroupLocalServiceUtil.getGroupsCount(
-			themeDisplay.getCompanyId(), Layout.class.getName(), getGroupId());
+			themeDisplay.getCompanyId(), Layout.class.getName(), _scopeGroupId);
 
 		groupSearch.setTotal(total);
 
 		List<Group> groups = GroupLocalServiceUtil.getGroups(
-			themeDisplay.getCompanyId(), Layout.class.getName(), getGroupId(),
+			themeDisplay.getCompanyId(), Layout.class.getName(), _scopeGroupId,
 			groupSearch.getStart(), groupSearch.getEnd());
 
 		groups = _filterLayoutGroups(groups, _isPrivateLayout());
@@ -108,5 +114,6 @@ public class LayoutScopesItemSelectorViewDisplayContext
 	}
 
 	private Boolean _privateLayout;
+	private long _scopeGroupId;
 
 }


### PR DESCRIPTION
Hello @gregory-bretall ,

https://issues.liferay.com/browse/LPS-78467

The issue is that the page scopes have been accidentally removed from asset publisher because in LayoutScopesItemSelectorViewDisplayContext.java, getGroupId() of

 int total = GroupLocalServiceUtil.getGroupsCount(
	themeDisplay.getCompanyId(), Layout.class.getName(), getGroupId());

 List<Group> groups = GroupLocalServiceUtil.getGroups(
	themeDisplay.getCompanyId(), Layout.class.getName(), getGroupId(),
 	groupSearch.getStart(), groupSearch.getEnd());

will always return null because getGroupId tries to fetch the groupId from request. However, the request does not contain groupId, thus causing groupId to always return 0 (null).

I fixed the issue by maintaining the original implementation by adding a condition that checks whether or not getGroupId() returns nothing. If it does not return any groupId, then I call the correct getScopeGroupId() of the themeDisplay which will fetch the right groupId so that you can also access groups.

Please let me know if you have any questions. Thanks.

Sincerely,
Brian Kim