### PR TITLE
LPS-78294 Fix Special Character Inconsistency in Documents and Media

### DIFF
--- a/modules/apps/collaboration/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_shortcut.jsp
+++ b/modules/apps/collaboration/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_shortcut.jsp
@@ -109,7 +109,7 @@ if (portletTitleBasedNavigation) {
 				String toGroupName = StringPool.BLANK;
 
 				if (toGroup != null) {
-					toGroupName = HtmlUtil.escape(toGroup.getDescriptiveName(locale));
+					toGroupName = toGroup.getDescriptiveName(locale);
 				}
 				%>
 
@@ -120,7 +120,7 @@ if (portletTitleBasedNavigation) {
 				</div>
 
 				<%
-				String toFileEntryTitle = BeanPropertiesUtil.getString(toFileEntry, "title");
+				String toFileEntryTitle = HtmlUtil.unescape(BeanPropertiesUtil.getString(toFileEntry, "title"));
 				%>
 
 				<div class="form-group">
@@ -175,7 +175,7 @@ if (portletTitleBasedNavigation) {
 					document.<portlet:namespace />fm.<portlet:namespace />toGroupId.value = event.groupid;
 					document.<portlet:namespace />fm.<portlet:namespace />toFileEntryId.value = 0;
 
-					document.getElementById('<portlet:namespace />toGroupName').value = _.escape(event.groupdescriptivename);
+					document.getElementById('<portlet:namespace />toGroupName').value = event.groupdescriptivename;
 
 					Liferay.Util.toggleDisabled('#<portlet:namespace />selectToFileEntryButton', false);
 				}

--- a/modules/apps/collaboration/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/select_file_entry.jsp
+++ b/modules/apps/collaboration/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/select_file_entry.jsp
@@ -102,11 +102,11 @@ dlSearchContainer.setResults(foldersAndFileEntriesAndFileShortcuts);
 								Map<String, Object> data = new HashMap<String, Object>();
 
 								data.put("entryid", fileEntry.getFileEntryId());
-								data.put("entryname", fileEntry.getTitle());
+								data.put("entryname", HtmlUtil.unescape(fileEntry.getTitle()));
 								%>
 
 								<aui:a cssClass="selector-button" data="<%= data %>" href="javascript:;">
-									<%= HtmlUtil.escape(fileEntry.getTitle()) %>
+									<%= fileEntry.getTitle() %>
 								</aui:a>
 
 								<c:if test="<%= Validator.isNotNull(fileEntry.getDescription()) %>">

--- a/modules/apps/collaboration/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/select_group.jsp
+++ b/modules/apps/collaboration/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/select_group.jsp
@@ -102,7 +102,7 @@ String eventName = ParamUtil.getString(request, "eventName", liferayPortletRespo
 					group = group.getStagingGroup();
 				}
 
-				String groupDescriptiveName = HtmlUtil.escape(group.getDescriptiveName(locale));
+				String groupDescriptiveName = group.getDescriptiveName(locale);
 
 				if (group.isUser()) {
 					groupDescriptiveName = LanguageUtil.get(request, "my-site");


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-78294

Hello @gregory-bretall ,

I am re-sending the PR with an updated fix.

There are currently four instances of incorrect escaping when you try to create a document file shortcut.

1.  When you create a brand new shortcut, and choose a site with special characters (&, '), the displayed site name does not escape correctly.
2. When you create a brand new shortcut, and click Select for Document, any documents listed with special characters are not displayed correctly in the list.
3. After you create the shortcut, the displayed site name does not escape correctly.
4. After you create the shortcut, the displayed document name does not escape correctly.

Number 1 is addressed by removing ._escape in line 178 of edit_file_shortcut.jsp and also by removing HtmlUtil.escape in line105 of select_group.jsp.
Number 2 is addressed by unescaping fileEntry.getTitle() in line 105 and and removing HtmlUtil.escape in line 109 of select_file_entry.jsp.
Number 3 is addressed by removing HtmlUtil.escape in line 112 of edit_file_shortcut.jsp.
Number 4 is addressed by unescaping BeanPropertiesUtil.getString(toFileEntry, "title") in line 123 of edit_file_shortcut.jsp.

If you have any questions, please let me know. Thanks.

Sincerely,
Brian Kim