### PR TITLE
LPS-78262 Fix Asset Publisher to show results of All Categories

### DIFF
--- a/modules/apps/web-experience/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/util/AssetPublisherUtil.java
+++ b/modules/apps/web-experience/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/util/AssetPublisherUtil.java
@@ -1504,6 +1504,9 @@ public class AssetPublisherUtil {
 
 			assetEntryQuery.setAllCategoryIds(newAllAssetCategoryIds);
 
+			assetEntryQuery.setGroupIds(
+				getGroupIds(portletPreferences, scopeGroupId, layout));
+
 			BaseModelSearchResult<AssetEntry> baseModelSearchResult =
 				getAssetEntries(
 					assetEntryQuery, layout, portletPreferences, portletName,


### PR DESCRIPTION
Hello @gregory-bretall,

https://issues.liferay.com/browse/LPS-78262

The issue is that displaying page scoped assets in asset publisher grouped by categories only shows the results from the first category. The reason for this is that only the first category retains the groupId of the scoped page while any additional categories use the groupId of guest page.

The solution is a simple fix that pre-assigns the scoped page groupIds of each category in AssetPublisherUtil by calling

assetEntryQuery.setGroupIds(
getGroupIds(portletPreferences, scopeGroupId, layout));
which sets the scoped page groupId to each assetEntryQuery before searching for hits.

If you have any questions, please let me know. Thanks.

Sincerely,
Brian Kim