### PR TITLE
LPS-78745 Strip HTML Tags from Wiki Search Result Content

### DIFF
--- a/modules/apps/collaboration/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/search.jsp
+++ b/modules/apps/collaboration/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/search.jsp
@@ -117,7 +117,7 @@ portletURL.setParameter("keywords", keywords);
 				commentRelatedSearchResults="<%= searchResult.getCommentRelatedSearchResults() %>"
 				containerName="<%= curNode.getName() %>"
 				cssClass='<%= MathUtil.isEven(index) ? "search" : "search alt" %>'
-				description="<%= (summary != null) ? summary.getContent() : wikiPage.getSummary() %>"
+				description="<%= (summary != null) ? HtmlUtil.stripHtml(summary.getContent()) : HtmlUtil.stripHtml(wikiPage.getSummary()) %>"
 				fileEntryRelatedSearchResults="<%= searchResult.getFileEntryRelatedSearchResults() %>"
 				highlightEnabled="<%= queryConfig.isHighlightEnabled() %>"
 				queryTerms="<%= hits.getQueryTerms() %>"


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-78745

Hello @gregory-bretall ,

The issue here is that when you search using a keyword that exists in the contents of a wiki in the wiki portlet, the HTML tags are shown along with the returned search results for contents.

The fix here is to use HtmlUtil to strip the HTML tags.

If you have any questions, please let me know. Thanks.

Sincerely,
Brian Kim