### PR TITLE
LPS-49726 Default notice type should be notice

### DIFF
--- a/modules/apps/foundation/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/notice.js
+++ b/modules/apps/foundation/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/notice.js
@@ -47,7 +47,7 @@ AUI.add(
 			instance._closeText = options.closeText;
 			instance._node = options.node;
 			instance._noticeType = options.type || 'notice';
-			instance._noticeClass = 'alert-warning';
+			instance._noticeClass = 'alert-notice';
 			instance._onClose = options.onClose;
 			instance._useCloseButton = true;
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-49726

When notice type is unspecified 'alert-notice' should be used as per [docs](https://github.com/gregory-bretall/liferay-portal/commit/b36afe894c57a300ee632498ed1ebbff2ab2cc84#diff-51a6d6103d83bb1aa89d54359bee42dcR35)