### PR TITLE
LPS 79021

### DIFF
--- a/modules/apps/collaboration/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/logic/DLPortletInstanceSettingsHelper.java
+++ b/modules/apps/collaboration/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/logic/DLPortletInstanceSettingsHelper.java
@@ -216,7 +216,7 @@ public class DLPortletInstanceSettingsHelper {
 	}
 
 	private String[] _getAllEntryColumns() {
-		String allEntryColumns = "name,size,status";
+		String allEntryColumns = "name,description,size,status";
 
 		if (PropsValues.DL_FILE_ENTRY_BUFFERED_INCREMENT_ENABLED) {
 			allEntryColumns += ",downloads";

--- a/modules/apps/collaboration/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_entries.jsp
+++ b/modules/apps/collaboration/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_entries.jsp
@@ -396,6 +396,14 @@ if (portletTitleBasedNavigation && (folderId != DLFolderConstants.DEFAULT_PARENT
 								</liferay-ui:search-container-column-text>
 							</c:if>
 
+							<c:if test='<%= ArrayUtil.contains(entryColumns, "description") %>'>
+								<liferay-ui:search-container-column-text
+									cssClass="table-cell-content"
+									name="description"
+									value="<%= StringUtil.shorten(HtmlUtil.stripHtml(fileEntry.getDescription()), 200) %>"
+								/>
+							</c:if>
+
 							<c:if test='<%= ArrayUtil.contains(entryColumns, "document-type") %>'>
 								<c:choose>
 									<c:when test="<%= latestFileVersion.getModel() instanceof DLFileVersion %>">
@@ -556,6 +564,14 @@ if (portletTitleBasedNavigation && (folderId != DLFolderConstants.DEFAULT_PARENT
 									href="<%= rowURL %>"
 									name="title"
 									value="<%= curFolder.getName() %>"
+								/>
+							</c:if>
+
+							<c:if test='<%= ArrayUtil.contains(entryColumns, "description") %>'>
+								<liferay-ui:search-container-column-text
+									cssClass="table-cell-content"
+									name="description"
+									value="<%= StringUtil.shorten(HtmlUtil.stripHtml(curFolder.getDescription()), 200) %>"
 								/>
 							</c:if>
 


### PR DESCRIPTION
Hello @gregory-bretall ,

https://issues.liferay.com/browse/LPS-79021

The issue is that list view for documents and media is not implemented correctly in that descriptions are not being shown as part of a description column when a user clicks list view.
The issue is a bug because in other portlets such as web content, list view indeed does show descriptions as part of a description column when a user clicks list view.

The fix is simple in that we can implement it by following the precedents already available such as:
https://github.com/liferay/liferay-portal/blob/d2ef24093db2b7ef6d254de0717018c07fb21362/modules/apps/web-experience/journal/journal-web/src/main/resources/META-INF/resources/view_entries.jsp#L189-L193

I have also updated DLPortletInstanceSettingsHelper to account for the new Description as well.

If you have any questions, please let me know. Thanks.

Sincerely,
Brian Kim