### PR TITLE
LPS-78904 Add style to content filter

### DIFF
--- a/modules/apps/foundation/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/js/alloyeditor.js
+++ b/modules/apps/foundation/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/js/alloyeditor.js
@@ -13,7 +13,7 @@ AUI.add(
 					attributes: ['alt', 'aria-*', 'height', 'href', 'src', 'width'],
 					classes: false,
 					elements: CKEDITOR.dtd,
-					styles: false
+					styles: true
 				}
 			}
 		);


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-78904

Previously from https://github.com/gregory-bretall/liferay-portal/pull/45

AlloyEditor sets the image size through [style](https://github.com/liferay/alloy-editor/blob/master/src/plugins/dragresize.js#L477-L486).  Currently when pasting we never write the style (specifically size) to a [new pasted object](https://github.com/SpencerWoo/liferay-portal/blob/570c4a0331fab4860439d80003ac0278656d1cc6/modules/apps/foundation/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/js/alloyeditor.js#L417).  The allows all pasted content (Web Content and Blogs) to retain size.