### PR TITLE
LPS-79300 Use Correct URL to Display Pages in Iframe Portlet

### DIFF
--- a/modules/apps/web-experience/iframe/iframe-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/web-experience/iframe/iframe-web/src/main/resources/META-INF/resources/view.jsp
@@ -90,10 +90,8 @@
 					var baseSrc = '<%= HtmlUtil.escapeJS(iFrameDisplayContext.getIframeBaseSrc()) %>';
 
 					if (!(/^https?\:\/\//.test(hash)) || !A.Lang.String.startsWith(hash, baseSrc)) {
-						src = '<%= HtmlUtil.escapeJS(iFrameDisplayContext.getIframeBaseSrc()) %>';
+						src = A.QueryString.escape(hash);
 					}
-
-					src += hash;
 
 					var iframe = A.one('#<portlet:namespace />iframe');
 


### PR DESCRIPTION
Hello @gregory-bretall ,

https://issues.liferay.com/browse/LPS-79300

The issue is that the Iframe Portlet is not using the correct page URLs specified in the configuration setting.
The reason for this is that the change introduced in

https://issues.liferay.com/browse/LPS-14110 (specifically this line:
https://github.com/liferay/liferay-portal/blob/ad00d8439ec2398f58ba4603ee7a922a9b6ae023/modules/apps/web-experience/iframe/iframe-web/src/main/resources/META-INF/resources/view.jsp#L96)

causes the hashURL to be added to the srcURL that is fetched from iFrameDisplayContext.getIframeBaseSrc().

The reason for this change in LPS-14110 was to ensure that each iframe portlet maintains its separability so that changes in one iframe portlet does not affect the other.

My change maintains the functionality fix from LPS-14110 and also fixes LPS-79300 by simply ensuring that the URL of the iframe portlet is the hashURL.

If you have any questions, please let me know. Thanks.

Sincerely,
Brian Kim

