### PR TITLE
LPS-79316 Display Correctly the Video Input Box for AlloyEditor

### DIFF
--- a/modules/apps/foundation/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/js/extras/buttons/embed/embed_video_edit.jsx
+++ b/modules/apps/foundation/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/js/extras/buttons/embed/embed_video_edit.jsx
@@ -4,8 +4,6 @@ var ReactDOM = AlloyEditor.ReactDOM;
 var KEY_ENTER = 13;
 var KEY_ESC = 27;
 
-var inputPlaceholder = Liferay.Language.get('paste-video-link');
-
 /**
  * The EmbedVideoEdit class provides functionality for embedding a social platform
  * video element in a document based on its original url.
@@ -84,6 +82,8 @@ var EmbedVideoEdit = React.createClass({
 		var editor = this.props.editor.get('nativeEditor');
 		var embed;
 
+		var inputPlaceholder = Liferay.Language.get('paste-video-link');
+
 		var selection = editor.getSelection();
 
 		if (selection) {
@@ -98,6 +98,7 @@ var EmbedVideoEdit = React.createClass({
 
 		return {
 			element: embed,
+			inputPlaceHolder: inputPlaceholder,
 			initialEmbed: {
 				videoURL: videoURL
 			},
@@ -121,7 +122,7 @@ var EmbedVideoEdit = React.createClass({
 		return (
 			<div className="ae-container-embed-video-edit">
 				<div className="ae-container-input xxl">
-					<input className="ae-input" onChange={this._handleVideoURLChange} onKeyDown={this._handleKeyDown} placeholder={inputPlaceholder} ref="linkInput" type="text" value={this.state.videoURL}></input>
+					<input className="ae-input" onChange={this._handleVideoURLChange} onKeyDown={this._handleKeyDown} placeholder={this.state.inputPlaceHolder} ref="linkInput" type="text" value={this.state.videoURL}></input>
 					<button aria-label={AlloyEditor.Strings.clearInput} className="ae-button ae-icon-remove" onClick={this._clearLink} style={clearVideoURLStyle} title={AlloyEditor.Strings.clear}></button>
 				</div>
 				<button aria-label={AlloyEditor.Strings.confirm} className="ae-button" disabled={!this._isValidState()} onClick={this._embedVideoURL} title={AlloyEditor.Strings.confirm}>


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-79316

Hello @gregory-bretall ,

The issue is that AlloyEditor displays the language key itself rather than the value for the placeholder value in the input box of video url displays.

The reason for this issue is that in

https://github.com/liferay/liferay-portal/blob/a7b8e110e522a66157c2a1b75c6b85c964a514d8/modules/apps/foundation/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/js/extras/buttons/embed/embed_video_edit.jsx#L7

https://github.com/liferay/liferay-portal/blob/a7b8e110e522a66157c2a1b75c6b85c964a514d8/modules/apps/foundation/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/js/extras/buttons/embed/embed_video_edit.jsx#L124

inputplaceholder is not initialized correctly.

The fix is to ensure that inputPlaceHolder is initialized & calls Liferay.Language.get('paste-video-link') and set it as a prop so that it can be passed onto as a state value.

If you have any questions, please let me know. Thanks.

Sincerely,
Brian Kim