### PR TITLE
LPS-79413 Strip HTML Tags from Title in Wiki Search Results

### DIFF
--- a/modules/apps/collaboration/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/search.jsp
+++ b/modules/apps/collaboration/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/search.jsp
@@ -125,7 +125,7 @@ portletURL.setParameter("keywords", keywords);
 				fileEntryRelatedSearchResults="<%= searchResult.getFileEntryRelatedSearchResults() %>"
 				highlightEnabled="<%= queryConfig.isHighlightEnabled() %>"
 				queryTerms="<%= hits.getQueryTerms() %>"
-				title="<%= (summary != null) ? summary.getTitle() : wikiPage.getTitle() %>"
+				title="<%= (summary != null) ? HtmlUtil.stripHtml(summary.getTitle()) : HtmlUtil.stripHtml(wikiPage.getTitle()) %>"
 				url="<%= rowURL %>"
 			/>
 		</liferay-ui:search-container-row>


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-79413

This is a variation of LPS-78745 in which the HTML Tags were present in contents in wiki search results.
The same issue occurs for searching titles as well in the wiki portlet.

The simple fix is to apply the same changes made to the contents by stripping the HTML from the potential title.

If you have any questions, please let me know. Thanks.

Sincerely,
Brian Kim