### PR TITLE
LPS-79427

### DIFF
--- a/modules/apps/foundation/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/taglib/_ratings.scss
+++ b/modules/apps/foundation/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/taglib/_ratings.scss
@@ -11,49 +11,17 @@
 		}
 	}
 
-	.rating-content {
-		display: block;
-	}
-
-	&.score {
-		white-space: nowrap;
-	}
-
 	&.like, &.thumbs {
-		float: left;
-		margin-bottom: 0;
-		margin-top: 0;
-
-		.thumbrating {
-			height: 32px;
-			line-height: 32px;
-			margin: 2px;
-
-			@include respond-to(phone, tablet) {
-				a {
-					font-size: 1.5em;
-				}
-			}
-
-			.rating-element:before {
-				padding-right: 4px;
-			}
+		a svg {
+			margin-right: 8px;
 		}
 	}
 
-	.rating-element {
-		padding-right: 4px;
+	.rating-input-container {
+		display: none;
 
-		&.rating-thumb-down {
-			margin-left: 5px;
+		.rating-input {
+			margin-left: 1px;
 		}
 	}
-
-	.rating-input-container .rating-input {
-		margin-left: 1px;
-	}
-}
-
-.js .taglib-ratings .liferay-rating-vote .rating-input-container {
-	display: none;
 }

--- a/modules/apps/foundation/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/taglib/_search_iterator.scss
+++ b/modules/apps/foundation/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/taglib/_search_iterator.scss
@@ -157,3 +157,7 @@
 .lfr-asset-folder {
 	min-width: 215px;
 }
+
+.searchcontainer-content .table-responsive-lg {
+	overflow: visible;
+}

--- a/modules/apps/foundation/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/ratings.js
+++ b/modules/apps/foundation/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/ratings.js
@@ -437,6 +437,14 @@ AUI.add(
 						instance.ratings = new A.ThumbRating(
 							{
 								boundingBox: '#' + namespace + 'ratingThumb',
+								cssClasses: {
+									down: '',
+									element: 'rating-off',
+									hover: 'rating-on',
+									off: 'rating-off',
+									on: 'rating-on',
+									up: ''
+								},
 								srcNode: '#' + namespace + 'ratingThumbContent'
 							}
 						).render();
@@ -551,7 +559,7 @@ AUI.add(
 
 								ratingThumbDown.attr('title', thumbDownMessage);
 
-								ratingThumbDown.html(thumbScore.negativeVotes);
+								ratingThumbDown.html(Liferay.Util.getLexiconIconTpl('thumbs-down') + thumbScore.negativeVotes);
 							}
 
 							if (ratingThumbDown && ratingThumbUpCssClassOn) {
@@ -570,7 +578,7 @@ AUI.add(
 							if (ratingThumbUp) {
 								ratingThumbUp.attr('title', thumbUpMessage);
 
-								ratingThumbUp.html(thumbScore.positiveVotes);
+								ratingThumbUp.html(Liferay.Util.getLexiconIconTpl('thumbs-up') + thumbScore.positiveVotes);
 							}
 						}
 					}
@@ -616,6 +624,14 @@ AUI.add(
 						instance.ratings = new LikeRatingImpl(
 							{
 								boundingBox: '#' + namespace + 'ratingLike',
+								cssClasses: {
+									down: '',
+									element: 'rating-off',
+									hover: 'rating-on',
+									off: 'rating-off',
+									on: 'rating-on',
+									up: ''
+								},
 								srcNode: '#' + namespace + 'ratingLikeContent'
 							}
 						).render();

--- a/portal-web/docroot/html/taglib/ui/ratings/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/ratings/page.jsp
@@ -192,10 +192,22 @@ if (!inTrash) {
 								}
 								%>
 
-								<span class="glyphicon glyphicon-thumbs-up rating-element rating-thumb-up rating-<%= (thumbUp) ? "on" : "off" %>" title="<%= thumbsTitle %>"><%= positiveVotes %></span>
+								<span class="btn btn-outline-borderless btn-outline-secondary btn-sm rating-element rating-thumb-up rating-<%= (thumbUp) ? "on" : "off" %>" title="<%= thumbsTitle %>">
+									<svg aria-hidden="true" class="lexicon-icon lexicon-icon-thumbs-up">
+										<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/lexicon/icons.svg#thumbs-up" />
+									</svg>
+
+									<%= positiveVotes %>
+								</span>
 
 								<c:if test="<%= type.equals(RatingsType.THUMBS.getValue()) %>">
-									<span class="glyphicon glyphicon-thumbs-down rating-element rating-thumb-down rating-<%= (thumbDown) ? "on" : "off" %>" title="<%= thumbsTitle %>"><%= negativeVotes %></span>
+									<span class="rating-element rating-thumb-down rating-<%= (thumbDown) ? "on" : "off" %>" title="<%= thumbsTitle %>">
+										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-thumbs-down">
+											<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/lexicon/icons.svg#thumbs-down" />
+										</svg>
+
+										<%= negativeVotes %>
+									</span>
 								</c:if>
 							</c:when>
 							<c:otherwise>
@@ -211,10 +223,22 @@ if (!inTrash) {
 								}
 								%>
 
-								<a class="glyphicon glyphicon-thumbs-up rating-element rating-thumb-up rating-<%= (thumbUp) ? "on" : "off" %>" href="javascript:;" title="<liferay-ui:message key="<%= positiveRatingMessage %>" />"><%= positiveVotes %></a>
+								<a class="btn btn-outline-borderless btn-outline-secondary btn-sm rating-element rating-thumb-up rating-<%= (thumbUp) ? "on" : "off" %>" href="javascript:;" title="<liferay-ui:message key="<%= positiveRatingMessage %>" />">
+									<svg aria-hidden="true" class="lexicon-icon lexicon-icon-thumbs-up">
+										<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/lexicon/icons.svg#thumbs-up" />
+									</svg>
+
+									<%= positiveVotes %>
+								</a>
 
 								<c:if test="<%= type.equals(RatingsType.THUMBS.getValue()) %>">
-									<a class="glyphicon glyphicon-thumbs-down rating-element rating-thumb-down rating-<%= (thumbDown) ? "on" : "off" %>" href="javascript:;" title="<liferay-ui:message key='<%= (thumbDown) ? "you-have-rated-this-as-bad" : "rate-this-as-bad" %>' />"><%= negativeVotes %></a>
+									<a class="btn btn-outline-borderless btn-outline-secondary btn-sm rating-element rating-thumb-down rating-<%= (thumbDown) ? "on" : "off" %>" href="javascript:;" title="<liferay-ui:message key='<%= (thumbDown) ? "you-have-rated-this-as-bad" : "rate-this-as-bad" %>' />">
+										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-thumbs-down">
+											<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/lexicon/icons.svg#thumbs-down" />
+										</svg>
+
+										<%= negativeVotes %>
+									</a>
 								</c:if>
 
 								<div class="rating-input-container">


### PR DESCRIPTION
Some of the permission options are not visible when a user has a smaller screen size/resolution unless they scroll all the way down to find the scroll bar. This can potentially be a security risk if the user is unaware that there are other available permissions.

I included CSS that will display a scroll bar for the user when there are more permissions off screen.
Let me know if you have any questions.

Thank you!