### PR TITLE
LPS-79427 Added CSS to display scroll bar for permissions when screen…

### DIFF
--- a/modules/apps/foundation/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/taglib/_search_iterator.scss
+++ b/modules/apps/foundation/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/taglib/_search_iterator.scss
@@ -157,3 +157,7 @@
 .lfr-asset-folder {
 	min-width: 215px;
 }
+
+.searchcontainer-content .table-responsive-lg {
+	overflow: visible;
+}


### PR DESCRIPTION
… size is small

Some of the permission options are not visible when a user has a smaller screen size/resolution unless they scroll all the way down to find the scroll bar. This can potentially be a security risk if the user is unaware that there are other available permissions.

I included CSS that will display a scroll bar for the user when there are more permissions off screen.
Let me know if you have any questions.

Thank you!