### PR TITLE
LPS-79505

### DIFF
--- a/modules/apps/collaboration/blogs/blogs-editor-configuration/src/main/java/com/liferay/blogs/editor/configuration/internal/BlogsContentEditorConfigContributor.java
+++ b/modules/apps/collaboration/blogs/blogs-editor-configuration/src/main/java/com/liferay/blogs/editor/configuration/internal/BlogsContentEditorConfigContributor.java
@@ -71,7 +71,7 @@ public class BlogsContentEditorConfigContributor
 
 		sb.append("a[*](*); ");
 		sb.append(getAllowedContentText());
-		sb.append(" div[*](*); iframe[*](*); img[*] {height, width}; ");
+		sb.append(" div[*](*); iframe[*](*); img[*] {display, float, height, margin-left, margin-right, width}; ");
 		sb.append(getAllowedContentLists());
 		sb.append(" p {text-align}; ");
 		sb.append(getAllowedContentTable());

--- a/modules/apps/collaboration/blogs/blogs-editor-configuration/src/main/java/com/liferay/blogs/editor/configuration/internal/BlogsContentEditorConfigContributor.java
+++ b/modules/apps/collaboration/blogs/blogs-editor-configuration/src/main/java/com/liferay/blogs/editor/configuration/internal/BlogsContentEditorConfigContributor.java
@@ -67,11 +67,12 @@ public class BlogsContentEditorConfigContributor
 		ThemeDisplay themeDisplay,
 		RequestBackedPortletURLFactory requestBackedPortletURLFactory) {
 
-		StringBundler sb = new StringBundler(6);
+		StringBundler sb = new StringBundler(7);
 
 		sb.append("a[*](*); ");
 		sb.append(getAllowedContentText());
-		sb.append(" div[*](*); iframe[*](*); img[*] {display, float, height, margin-left, margin-right, width}; ");
+		sb.append(" div[*](*); iframe[*](*); ");
+		sb.append(" img[*] {display, float, height, margin-left, margin-right, width}; ")
 		sb.append(getAllowedContentLists());
 		sb.append(" p {text-align}; ");
 		sb.append(getAllowedContentTable());


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-79505

Change blog filtering to allow float, display, margin-left, and margin-right otherwise they are stripped/filtered on view toggle and publish.  These four styles are applied with alloyeditor's wysiwyg align buttons.