### PR TITLE
LPS-79454 Added CSS to fix image render in Blogs IE11

### DIFF
--- a/modules/apps/foundation/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/portal/_editor_alloy.scss
+++ b/modules/apps/foundation/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/portal/_editor_alloy.scss
@@ -103,6 +103,10 @@
 				}
 			}
 		}
+
+		.cke_widget_wrapper {
+			display: block;
+		}
 	}
 
 	.alloy-editor-switch {


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-79454
When editing a blog post with an image in IE11, the image will be rendered incorrectly. This is due to the display being overwritten to inline-block.
I added CSS that will take priority in IE11 and set the display to block and render the image correctly.

If there is any questions please let me know.
Thank you!