### PR TITLE
LPS-79119 Added CSS to keep image inside portlet container

### DIFF
--- a/modules/apps/collaboration/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/css/common_main.scss
+++ b/modules/apps/collaboration/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/css/common_main.scss
@@ -68,6 +68,12 @@
 			vertical-align: top !important;
 		}
 	}
+
+	.widget-mode-detail-text {
+		img {
+			max-width: 100%;
+		}
+	}
 }
 
 .firefox .portlet-blogs fieldset {


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-79119

In Blogs, large images will extend passed the portlet container. This happens because of the removal of the CSS "entry-content":  [here](https://github.com/liferay/liferay-portal/commit/2b213d94a746ab6e4390add8f52e446ed8504632#diff-370ce2e6d41a34c96ab31983029106afL161). The css would keep the image from extending passed the container.

I added CSS to match the current implementation of the portlet and have the image wrap within the portlet. 

If there are any questions please let me know.
Thank you!