### PR TITLE
LPS-79606 Created a check for localizationMap if it is an object

### DIFF
--- a/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
+++ b/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
@@ -789,8 +789,10 @@ AUI.add(
 
 						var value = instance.getValue();
 
-						if (AObject.keys(localizationMap).length != 0) {
-							this.removeNotAvailableLocales(localizationMap);
+						if (typeof localizationMap === 'object') {
+							if (AObject.keys(localizationMap).length != 0) {
+								this.removeNotAvailableLocales(localizationMap);
+							}
 						}
 
 						if (instance.get('localizable')) {


### PR DESCRIPTION
Trying to publish a web content with ddm-geolocation in IE11 will result in a `Object.keys: argument is not an Object.` error in the devTool console. This is due to the fact that `localizationMap` is a String when ddm-geolocation is being used.

By creating a check to see if `localizationMap` is an Object, it will prevent this error from occurring. 
If there are any questions or comments please let me know.

Thank you.