### PR TITLE
Lps 79521

### DIFF
--- a/modules/apps/web-experience/journal/journal-web/src/main/java/com/liferay/journal/web/asset/JournalArticleAssetRenderer.java
+++ b/modules/apps/web-experience/journal/journal-web/src/main/java/com/liferay/journal/web/asset/JournalArticleAssetRenderer.java
@@ -54,6 +54,7 @@ import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 
@@ -226,7 +227,8 @@ public class JournalArticleAssetRenderer
 					_article, null, null, LanguageUtil.getLanguageId(locale), 1,
 					portletRequestModel, themeDisplay);
 
-			summary = HtmlUtil.stripHtml(articleDisplay.getContent());
+			summary = StringUtil.shorten(
+				HtmlUtil.extractText(articleDisplay.getContent()), 200);
 		}
 		catch (Exception e) {
 		}

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetEntryLocalServiceImpl.java
@@ -633,6 +633,10 @@ public class AssetEntryLocalServiceImpl extends AssetEntryLocalServiceBaseImpl {
 				description, assetCategoryIds, assetTagNames, showNonindexable,
 				statuses, andSearch, QueryUtil.ALL_POS, QueryUtil.ALL_POS);
 
+			if ((description == title) && (description == userName)) {
+				searchContext.setKeywords(description);
+			}
+
 			QueryConfig queryConfig = searchContext.getQueryConfig();
 
 			queryConfig.setHighlightEnabled(false);


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-79521

Hello @gregory-bretall ,

The issue is that pagination in search for web content display is not working correctly when you search for content in a web content.
There are multiple layers for the reason that this issue is occuring.

When page.jsp (https://github.com/liferay/liferay-portal/blob/master/portal-web/docroot/html/taglib/ui/search_paginator/page.jsp) is called to render the pagination bar at the bottom, it only renders the pagination bar if the searchContainer.getTotal() is greater than 0. In this case, getTotal() returns 0 because

https://github.com/liferay/liferay-portal/blob/5688f44cdc366f55240dbc0ce32f85b8675f656f/modules/apps/web-experience/asset/asset-browser-web/src/main/java/com/liferay/asset/browser/web/internal/display/context/AssetBrowserDisplayContext.java#L485

calls the method searchCount which ultimately leads to

https://github.com/liferay/liferay-portal/blob/f57516d0ede71a811898214b5cc1d5cd5bd8f04a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetEntryLocalServiceImpl.java#L594-L602

being called. Here, the method returns:

return searchCount(
			companyId, groupIds, userId, className, classTypeId, keywords,
keywords, keywords, null, null, showNonindexable, statuses, false);

Here, the keywords are passed as parameter three times, once each for Username, Title, and Description.
However, this implementation is incorrect because the Description column in Web Content Display returns the content if Description is empty. Thus, the search should also be doing a hit search for content as well.

Therefore, the fix is to check whether all three search parameters are being passed with the same keyword value, and set the searchContext keywords attribute to the said keyword. This avoids the version change that occurs from a new method implementation.

There are two commits here. The first one is to ensure that when the content is used as the summary, we should be extracting only the text from the web content and shorten the summary. The second commit implements the condition that checks whether all three search parameters are the same keywords, then we can use any one of them set the keywords in searchContext.

If you have any questions, please let me know. Thanks.

Sincerely,
Brian Kim