### PR TITLE
LPS-79748 permissive filterGroups based on permissions instead of roles

### DIFF
--- a/modules/apps/web-experience/site/site-browser-web/src/main/java/com/liferay/site/browser/web/internal/display/context/SiteBrowserDisplayContext.java
+++ b/modules/apps/web-experience/site/site-browser-web/src/main/java/com/liferay/site/browser/web/internal/display/context/SiteBrowserDisplayContext.java
@@ -28,9 +28,11 @@ import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.PortalPreferences;
 import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
+import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
@@ -120,7 +122,10 @@ public class SiteBrowserDisplayContext {
 
 		boolean filterManageableGroups = true;
 
-		if (permissionChecker.isCompanyAdmin()) {
+		if (GroupPermissionUtil.contains(
+				permissionChecker, user.getGroupId(),
+				ActionKeys.ASSIGN_MEMBERS)) {
+
 			filterManageableGroups = false;
 		}
 
@@ -416,7 +421,10 @@ public class SiteBrowserDisplayContext {
 		List<Group> filteredGroups = new ArrayList();
 
 		for (Group group : groups) {
-			if (permissionChecker.isGroupAdmin(group.getGroupId())) {
+			if (GroupPermissionUtil.contains(
+					permissionChecker, group.getGroupId(),
+					ActionKeys.ASSIGN_MEMBERS)) {
+
 				filteredGroups.add(group);
 			}
 		}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-79748

Filter groups based on assign permissions instead of administrator roles.

In testing this does not regress https://issues.liferay.com/browse/LPS-69252 (origin of the permissionChecker code lines I'm modifying).