### PR TITLE
LPS-80356 AObject.keys requires explicit object for ES5 compliant bro…

### DIFF
--- a/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
+++ b/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
@@ -766,11 +766,16 @@ AUI.add(
 
 							instance.updateTranslationsDefaultValue();
 
-							fieldJSON.value = instance.get('localizationMap');
+							var localizationMap = instance.get('localizationMap');
+
+							fieldJSON.value = localizationMap;
 
 							var form = instance.getForm();
 
-							form.addAvailableLanguageIds(AObject.keys(fieldJSON.value));
+							if (localizationMap == "false" || localizationMap == "true") {
+								localizationMap = new Boolean(localizationMap);
+							}
+							form.addAvailableLanguageIds(AObject.keys(localizationMap));
 						}
 
 						var fields = instance.get('fields');
@@ -790,6 +795,10 @@ AUI.add(
 						var value = instance.getValue();
 
 						if (Lang.isObject(localizationMap)) {
+							if (localizationMap == "false" || localizationMap == "true") {
+								localizationMap = new Boolean(localizationMap);
+							}
+
 							if (AObject.keys(localizationMap).length != 0) {
 								this.removeNotAvailableLocales(localizationMap);
 							}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-80356

The issue is IE11 is ES5 and throws an error instead of implicitly casting.  The solution here is to create a boolean object when lowercase string boolean.  There are others ways for a fix but this seemed the cleanest to me.