### PR TITLE
LPS-79998 Added css form-control to blogs/wiki content to make adding…

### DIFF
--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/edit_entry.jsp
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/edit_entry.jsp
@@ -208,6 +208,7 @@ if (portletTitleBasedNavigation) {
 						<div class="entry-content form-group">
 							<liferay-ui:input-editor
 								contents="<%= content %>"
+								cssClass="form-control"
 								editorName='<%= PropsUtil.get("editor.wysiwyg.portal-web.docroot.html.portlet.blogs.edit_entry.jsp") %>'
 								name="contentEditor"
 								onChangeMethod="OnChangeEditor"

--- a/modules/apps/wiki/wiki-engine-input-editor-common/src/main/resources/META-INF/resources/edit_page.jsp
+++ b/modules/apps/wiki/wiki-engine-input-editor-common/src/main/resources/META-INF/resources/edit_page.jsp
@@ -31,6 +31,7 @@ String content = BeanParamUtil.getString(wikiPage, request, "content");
 	<liferay-ui:input-editor
 		configParams="<%= configParams %>"
 		contents="<%= content %>"
+		cssClass="form-control"
 		editorName="<%= baseWikiEngine.getEditorName() %>"
 		fileBrowserParams="<%= fileBrowserParams %>"
 		name="contentEditor"


### PR DESCRIPTION
… content easier

https://issues.liferay.com/browse/LPS-79998

When adding an image that is larger than the width of the blog/wiki content box, the image will be resized and it will be impossible for the user to add content above or below the image. Resizing the image, adding your text, and then resizing back is the only current way to do this.

A solution to this is adding the css class "form-control" to the alloy-editor in order for clay to add css that will create a border around the content making it easier to add content. The "form-control" has already been added in web content and message board.

Because of this change, the background color of the content box will display green when there is content and red when there is no content to notify the user that this field is required. This behavior is also seen in the message board's subject title.

If there are any comment or questions please let me know.
Thank you!