### PR TITLE
LPS-82049 Append the HTTP method to the cache key to keep it unique

### DIFF
--- a/portal-impl/src/com/liferay/portal/servlet/filters/cache/CacheFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/cache/CacheFilter.java
@@ -95,6 +95,10 @@ public class CacheFilter extends BasePortalFilter {
 	protected String getCacheKey(HttpServletRequest request) {
 		StringBundler sb = new StringBundler(9);
 
+		//Method
+
+		sb.append(request.getMethod());
+
 		// Url
 
 		sb.append(request.getRequestURL());


### PR DESCRIPTION
When a HEAD request is sent to a site on Liferay, a key is created and the request is cached. When a GET request is sent after HEAD, the keys end up being the same and the response will return nothing. This breaks the GET request since it should return the HTML of the page.

A fix for this issue is to append the HTTP method that is calling the request to the key. Since the keys will become unique it will work correctly without any issues.
Let me know if there are any comments or questions about this.

Thank you!