### PR TITLE
LPS-82327 Created a check for the filename to prevent xss

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/servlet/ServletResponseUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/servlet/ServletResponseUtil.java
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.MimeTypesUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
@@ -640,6 +641,8 @@ public class ServletResponseUtil {
 		if (Validator.isNull(fileName)) {
 			return;
 		}
+
+		fileName = HtmlUtil.escapeURL(fileName);
 
 		String contentDispositionFileName = "filename=\"" + fileName + "\"";
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-82327

An xss attack can occur if a script is disguised as an image and contains ".html#" in the filename before the extension. A solution to this problem can be to search through the file name for ".html#" and remove the text completely. This way whether the image is downloaded or displayed, the user will no longer be at risk of running the script. I have checked other extensions such as .xml, .js, and have found that these will only display the script to the screen, but not run the script. 

For this solution I decided to replace it with `DOUBLE_DASH` which was a style choice and could be changed to anything that seems more suitable. With this change, the file will no longer run the script and instead it will display a corrupted image to the screen.

I decided to check the `fileName` in `ServletResponseUtil` since this is the step right before the file is decided to either be downloaded or displayed to the user.

If there are any comments or questions please let me know.
Thank you!