### PR TITLE
LPS-82664 Add margins next to images in web content editor when image…

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/css/main.scss
@@ -2,6 +2,14 @@
 	.article-content-content {
 		img {
 			max-width: 100%;
+
+			&[style*="float: left;"], &[style*="float:left;"] {
+				margin-right: 24px;
+			}
+
+			&[style*="float: right;"], &[style*="float:right;"] {
+				margin-left: 24px;
+			}
 		}
 
 		.form-builder-field {


### PR DESCRIPTION
… is left or right aligned

https://issues.liferay.com/browse/LPS-82664

This issue is in web content alloy editor and is similar to https://issues.liferay.com/browse/LPS-78690. This is also solved with the same css. Margins are applied to a left/right aligned image when text is added.
Let me know if there are any comments or questions.
Thank you.