### PR TITLE
[TS] LPS-82700 Browse icon isn't visible when using images to link

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/java/com/liferay/frontend/editor/alloyeditor/web/internal/editor/configuration/AlloyEditorConfigContributor.java
+++ b/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/java/com/liferay/frontend/editor/alloyeditor/web/internal/editor/configuration/AlloyEditorConfigContributor.java
@@ -224,7 +224,8 @@ public class AlloyEditorConfigContributor
 
 		jsonObject.put(
 			"buttons",
-			toJSONArray("['imageLeft', 'imageCenter', 'imageRight', 'link']"));
+			toJSONArray("['imageLeft', 'imageCenter', 'imageRight', " +
+							"'linkBrowse']"));
 		jsonObject.put("name", "image");
 		jsonObject.put("test", "AlloyEditor.SelectionTest.image");
 


### PR DESCRIPTION
Hi @gregory-bretall,

please check my fix regarding browse icon on image.

https://issues.liferay.com/browse/LPP-30582
SMER: https://issues.liferay.com/browse/LPP-30566

Thanks, Roland