### PR TITLE
LPS-82667 increase User image max dimensions

### DIFF
--- a/modules/apps/users-admin/users-admin-api/src/main/java/com/liferay/users/admin/configuration/UserFileUploadsConfiguration.java
+++ b/modules/apps/users-admin/users-admin-api/src/main/java/com/liferay/users/admin/configuration/UserFileUploadsConfiguration.java
@@ -36,13 +36,13 @@ public interface UserFileUploadsConfiguration {
 	public long imageMaxSize();
 
 	@Meta.AD(
-		deflt = "120", description = "users-image-maximum-height-help",
+		deflt = "226", description = "users-image-maximum-height-help",
 		name = "maximum-height", required = false
 	)
 	public int imageMaxHeight();
 
 	@Meta.AD(
-		deflt = "100", description = "users-image-maximum-width-help",
+		deflt = "226", description = "users-image-maximum-width-help",
 		name = "maximum-width", required = false
 	)
 	public int imageMaxWidth();

--- a/modules/apps/users-admin/users-admin-api/src/main/resources/com/liferay/users/admin/configuration/packageinfo
+++ b/modules/apps/users-admin/users-admin-api/src/main/resources/com/liferay/users/admin/configuration/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.0.1


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-82667

I'm unaware of a good reason to keep 120x100.  Customers can change these values to suite their needs however with OOTB Master/DXP Site Membership Icon View often stretches these images because 120x100 is too small.