### PR TITLE
LPS-82792 Reset fileName when file is not accepted

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/logo_editor.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/logo_editor.js
@@ -111,6 +111,8 @@ AUI.add(
 						if (Lang.isObject(responseText)) {
 							if (responseText.errorMessage) {
 								instance._showError(responseText.errorMessage);
+
+								instance._fileNameNode.set('value', '');
 							}
 
 							if (responseText.tempImageFileName) {


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-82792

When a user tries to upload a non-image file to profile picture an error will display. If they try to upload the same file again there is no error message. The reason the error message will not display again is due to the fact that the listener is waiting for a different file to be activated. Since it stores the last file, it will not trigger as another upload. 
A solution is to reset the fileName when there is an error with the file. So if the user continues to upload the same file it will tell them it is an incompatible file. 
If there are any questions or comments please let me know.
Thank you.