### PR TITLE
LPS-82965 clear alertsContainer

### DIFF
--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/message_util.js
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/message_util.js
@@ -167,7 +167,7 @@ AUI.add(
 				var alert = instance._alert;
 
 				if (alert) {
-					alert.destroy();
+					alert._alertsContainer._node.innerHTML = "";
 				}
 
 				alert = new Liferay.Alert(


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-82965

destroy() is leaving the wrapper yet destroying the widget-transition timer such that the wrapper never transitions from 58px to 0px.  By clearing the innerHTML we have the intended behavior of only having one alert at a time and not cluttering the DOM.