### PR TITLE
LPS-83069 clear alertsContainer

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/form_portlet.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/form_portlet.js
@@ -1025,7 +1025,7 @@ AUI.add(
 						var alert = instance.get('alert');
 
 						if (alert) {
-							alert.destroy();
+							alert._alertsContainer._node.innerHTML = "";
 						}
 
 						var icon = 'exclamation-full';


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-83069

This one isn't customer driven but same fix as https://github.com/gregory-bretall/liferay-portal/pull/92

destroy() is leaving the wrapper yet destroying the widget-transition timer such that the wrapper never transitions from 58px to 0px.  By clearing the innerHTML we have the intended behavior of only having one alert at a time and not cluttering the DOM.