### PR TITLE
LPS-84652 Add styles to keep anchor link title visible

### DIFF
--- a/modules/apps/product-navigation/product-navigation-control-menu-theme-contributor/src/main/resources/META-INF/resources/control_menu/_control_menu.scss
+++ b/modules/apps/product-navigation/product-navigation-control-menu-theme-contributor/src/main/resources/META-INF/resources/control_menu/_control_menu.scss
@@ -9,6 +9,13 @@
 			visibility: hidden;
 		}
 
+		:target::before {
+			content: '';
+			display: block;
+			height: $has-control-menu-margin-top-mobile;
+			margin: -$has-control-menu-margin-top-mobile 0 0;
+		}
+
 		@include sm() {
 			margin-top: $has-control-menu-margin-top-desktop;
 
@@ -17,6 +24,13 @@
 				position: relative;
 				top: -$has-control-menu-margin-top-desktop;
 				visibility: hidden;
+			}
+
+			:target::before {
+				content: '';
+				display: block;
+				height: $has-control-menu-margin-top-desktop;
+				margin: -$has-control-menu-margin-top-desktop 0 0;
 			}
 		}
 	}
@@ -31,6 +45,13 @@
 			visibility: hidden;
 		}
 
+		:target::before {
+			content: '';
+			display: block;
+			height: ($has-control-menu-margin-top-mobile + $has-customization-menu-margin-top-mobile);
+			margin: -($has-control-menu-margin-top-mobile + $has-customization-menu-margin-top-mobile) 0 0;
+		}
+
 		@include sm() {
 			margin-top: ($has-control-menu-margin-top-desktop + $has-customization-menu-margin-top-desktop);
 
@@ -39,6 +60,13 @@
 				position: relative;
 				top: -($has-control-menu-margin-top-desktop + $has-customization-menu-margin-top-desktop);
 				visibility: hidden;
+			}
+
+			:target::before {
+				content: '';
+				display: block;
+				height: ($has-control-menu-margin-top-desktop + $has-customization-menu-margin-top-desktop);
+				margin: -($has-control-menu-margin-top-desktop + $has-customization-menu-margin-top-desktop) 0 0;
 			}
 		}
 	}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-84652

When clicking an anchor link to jump to a part of content, the control menu panel will cut off the beginning content. To fix this, I made a call to the `:target` that is being selected and added a header in order to lower the content to be visible.

If there are any questions or comments please let me know.
Thank you.