### PR TITLE
LPS-85076 Do not set cancel button URL if redirect is empty String

### DIFF
--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/js/blogs.js
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/js/blogs.js
@@ -441,7 +441,9 @@ AUI.add(
 													var cancelButton = instance.one('#cancelButton');
 
 													if (cancelButton) {
-														cancelButton.attr('href', message.redirect);
+														if (message.redirect != '') {
+															cancelButton.attr('href', message.redirect);
+														}
 													}
 
 													if (saveStatus) {


### PR DESCRIPTION
During the blogs auto save, the URL of the cancel button is set to an empty string. This makes the cancel button to redirect to the home page. A solution to this is to check whether the link and decide if it should be changed.
Let me know if there are any questions or comments about this.
Thank you.