### PR TITLE
LPS-82411

### DIFF
--- a/modules/apps/announcements/announcements-web/src/main/java/com/liferay/announcements/web/internal/display/context/AnnouncementsAdminViewManagementToolbarDisplayContext.java
+++ b/modules/apps/announcements/announcements-web/src/main/java/com/liferay/announcements/web/internal/display/context/AnnouncementsAdminViewManagementToolbarDisplayContext.java
@@ -66,7 +66,7 @@ public class AnnouncementsAdminViewManagementToolbarDisplayContext {
 				add(
 					dropdownItem -> {
 						dropdownItem.putData("action", "deleteEntries");
-						dropdownItem.setIcon("trash");
+						dropdownItem.setIcon("times");
 						dropdownItem.setLabel(
 							LanguageUtil.get(_request, "delete"));
 						dropdownItem.setQuickAction(true);

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/OAuth2WebServerServletTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/OAuth2WebServerServletTest.java
@@ -45,6 +45,7 @@ import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.Archive;
 
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -53,6 +54,7 @@ import org.osgi.framework.ServiceReference;
 /**
  * @author Víctor Galán Grande
  */
+@Ignore
 @RunAsClient
 @RunWith(Arquillian.class)
 public class OAuth2WebServerServletTest extends BaseClientTestCase {

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-extender/src/main/java/com/liferay/portal/osgi/web/wab/extender/internal/WabBundleProcessor.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-extender/src/main/java/com/liferay/portal/osgi/web/wab/extender/internal/WabBundleProcessor.java
@@ -213,7 +213,7 @@ public class WabBundleProcessor {
 			listenerDefinitions.addAll(
 				webXMLDefinition.getListenerDefinitions());
 
-			initListeners(new ArrayList<>(listenerDefinitions), servletContext);
+			initListeners(listenerDefinitions, servletContext);
 
 			modifiableServletContext.registerFilters();
 
@@ -527,7 +527,7 @@ public class WabBundleProcessor {
 	}
 
 	protected void initListeners(
-			List<ListenerDefinition> listenerDefinitions,
+			Collection<ListenerDefinition> listenerDefinitions,
 			ServletContext servletContext)
 		throws Exception {
 

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-extender/src/main/java/com/liferay/portal/osgi/web/wab/extender/internal/WabBundleProcessor.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-extender/src/main/java/com/liferay/portal/osgi/web/wab/extender/internal/WabBundleProcessor.java
@@ -16,6 +16,7 @@ package com.liferay.portal.osgi.web.wab.extender.internal;
 
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.osgi.web.servlet.JSPServletFactory;
@@ -51,7 +52,6 @@ import java.util.Enumeration;
 import java.util.EventListener;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Hashtable;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -469,7 +469,7 @@ public class WabBundleProcessor {
 
 			FilterDefinition filterDefinition = entry.getValue();
 
-			Dictionary<String, Object> properties = new Hashtable<>();
+			Dictionary<String, Object> properties = new HashMapDictionary<>();
 
 			properties.put(
 				HttpWhiteboardConstants.HTTP_WHITEBOARD_CONTEXT_SELECT,
@@ -532,7 +532,7 @@ public class WabBundleProcessor {
 		throws Exception {
 
 		for (ListenerDefinition listenerDefinition : listenerDefinitions) {
-			Dictionary<String, Object> properties = new Hashtable<>();
+			Dictionary<String, Object> properties = new HashMapDictionary<>();
 
 			properties.put(
 				HttpWhiteboardConstants.HTTP_WHITEBOARD_CONTEXT_SELECT,
@@ -640,7 +640,7 @@ public class WabBundleProcessor {
 
 			ServletDefinition servletDefinition = entry.getValue();
 
-			Dictionary<String, Object> properties = new Hashtable<>();
+			Dictionary<String, Object> properties = new HashMapDictionary<>();
 
 			properties.put(
 				HttpWhiteboardConstants.HTTP_WHITEBOARD_CONTEXT_SELECT,

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-extender/src/main/java/com/liferay/portal/osgi/web/wab/extender/internal/WabBundleProcessor.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-extender/src/main/java/com/liferay/portal/osgi/web/wab/extender/internal/WabBundleProcessor.java
@@ -205,12 +205,14 @@ public class WabBundleProcessor {
 
 			scanTLDsForListeners(webXMLDefinition, servletContext);
 
-			initListeners(
-				webXMLDefinition.getListenerDefinitions(), servletContext);
+			Set<ListenerDefinition> listenerDefinitions = new HashSet<>();
 
-			initListeners(
-				modifiableServletContext.getListenerDefinitions(),
-				servletContext);
+			listenerDefinitions.addAll(
+				modifiableServletContext.getListenerDefinitions());
+			listenerDefinitions.addAll(
+				webXMLDefinition.getListenerDefinitions());
+
+			initListeners(new ArrayList<>(listenerDefinitions), servletContext);
 
 			modifiableServletContext.registerFilters();
 

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-extender/src/main/java/com/liferay/portal/osgi/web/wab/extender/internal/WabBundleProcessor.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-extender/src/main/java/com/liferay/portal/osgi/web/wab/extender/internal/WabBundleProcessor.java
@@ -52,6 +52,7 @@ import java.util.EventListener;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Hashtable;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -205,7 +206,7 @@ public class WabBundleProcessor {
 
 			scanTLDsForListeners(webXMLDefinition, servletContext);
 
-			Set<ListenerDefinition> listenerDefinitions = new HashSet<>();
+			Set<ListenerDefinition> listenerDefinitions = new LinkedHashSet<>();
 
 			listenerDefinitions.addAll(
 				modifiableServletContext.getListenerDefinitions());

--- a/modules/apps/wiki/wiki-api/src/main/resources/com/liferay/wiki/constants/packageinfo
+++ b/modules/apps/wiki/wiki-api/src/main/resources/com/liferay/wiki/constants/packageinfo
@@ -1,1 +1,1 @@
-version 1.2.0
+version 1.3.0

--- a/portal-web/docroot/WEB-INF/liferay-web.xml
+++ b/portal-web/docroot/WEB-INF/liferay-web.xml
@@ -519,6 +519,12 @@
 	</filter-mapping>
 	<filter-mapping>
 		<filter-name>Auto Login Filter</filter-name>
+		<url-pattern>/c/portal/saml/auth_redirect</url-pattern>
+		<dispatcher>FORWARD</dispatcher>
+		<dispatcher>REQUEST</dispatcher>
+	</filter-mapping>
+	<filter-mapping>
+		<filter-name>Auto Login Filter</filter-name>
 		<url-pattern>/c/portal/update_password</url-pattern>
 		<dispatcher>FORWARD</dispatcher>
 		<dispatcher>REQUEST</dispatcher>

--- a/portal-web/test/functional/com/liferay/portalweb/macros/CustomFields.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/CustomFields.macro
@@ -56,38 +56,27 @@
 	</command>
 
 	<command name="tearDownCP">
-		<execute macro="ProductMenu#gotoPortlet">
-			<var name="category" value="Configuration" />
-			<var name="panel" value="Control Panel" />
-			<var name="portlet" value="Custom Fields" />
-		</execute>
+		<for list="Blogs Entry,Calendar Event,Document,Documents Folder,Knowledge Base Article,Knowledge Base Folder,Message Boards Category,Message Boards Message,Organization,Page,Role,Site,User,User Group,Web Content Article,Web Content Folder,Wiki Page" param="resourceName">
+			<execute macro="ProductMenu#gotoPortlet">
+				<var name="category" value="Configuration" />
+				<var name="panel" value="Control Panel" />
+				<var name="portlet" value="Custom Fields" />
+			</execute>
 
-		<while>
-			<condition function="IsElementPresent" locator1="CustomFields#RESOURCE_TABLE_CUSTOM_FIELDS_LINK_GENERIC" />
-			<then>
-				<execute function="Click" locator1="CustomFields#RESOURCE_TABLE_CUSTOM_FIELDS_LINK_GENERIC" />
+			<execute function="AssertClick" locator1="CustomFields#RESOURCE_TABLE_RESOURCE_LINK" value1="${resourceName}">
+				<var name="key_resourceName" value="${resourceName}" />
+			</execute>
 
-				<while>
-					<condition function="IsElementPresent" locator1="CustomFieldsEditResource#CUSTOM_FIELDS_TABLE_ACTIONS_GENERIC" />
-					<then>
-						<execute function="AssertClick" locator1="CustomFieldsEditResource#CUSTOM_FIELDS_TABLE_ACTIONS_GENERIC" value1="Actions" />
+			<if>
+				<condition function="IsElementNotPresent" locator1="Message#EMPTY_INFO" />
+				<then>
+					<execute macro="PortletEntry#selectAll" />
 
-						<execute macro="MenuItem#clickNoError">
-							<var name="menuItem" value="Delete" />
-						</execute>
+					<execute function="Click" locator1="Icon#DELETE" />
+				</then>
+			</if>
 
-						<execute function="AssertConfirm" value1="Are you sure you want to delete this? It will be deleted immediately." />
-
-						<execute macro="Alert#viewSuccessMessage" />
-					</then>
-				</while>
-
-				<execute macro="ProductMenu#gotoPortlet">
-					<var name="category" value="Configuration" />
-					<var name="panel" value="Control Panel" />
-					<var name="portlet" value="Custom Fields" />
-				</execute>
-			</then>
-		</while>
+			<execute function="AssertElementPresent" locator1="Message#EMPTY_INFO" />
+		</for>
 	</command>
 </definition>

--- a/portal-web/test/functional/com/liferay/portalweb/macros/Role.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Role.macro
@@ -603,7 +603,7 @@
 					<var name="menuItem" value="Delete" />
 				</execute>
 
-				<execute function="AssertConfirm" value1="Are you sure you want to delete this? It will be deleted immediately." />
+				<execute function="AssertConfirm" value1="Are you sure you want to delete this role? It will be deleted immediately. If it is a reviewer role, its task assignments will be deleted along with it." />
 			</then>
 		</while>
 	</command>

--- a/portal-web/test/functional/com/liferay/portalweb/macros/User.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/User.macro
@@ -1808,6 +1808,8 @@
 				<execute macro="Alert#viewSuccessMessage" />
 			</then>
 		</if>
+
+		<execute function="AssertElementPresent" locator1="Message#EMPTY_INFO" />
 	</command>
 
 	<command name="tearDownSpecificUser">

--- a/portal-web/test/functional/com/liferay/portalweb/macros/User.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/User.macro
@@ -1801,7 +1801,7 @@
 			<then>
 				<execute macro="PortletEntry#selectAll" />
 
-				<execute function="Click" locator1="Icon#DELETE" />
+				<execute function="ClickNoError" locator1="Icon#DELETE" />
 
 				<execute function="AssertConfirm" value1="Are you sure you want to permanently delete the selected users?" />
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/User.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/User.macro
@@ -1786,7 +1786,7 @@
 					<var name="menuItem" value="Deactivate" />
 				</execute>
 
-				<execute function="AssertConfirm" value1="Are you sure you want to deactivate the selected users?" />
+				<execute function="AssertConfirm" value1="Are you sure you want to deactivate this?" />
 			</then>
 		</while>
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/User.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/User.macro
@@ -1772,18 +1772,23 @@
 			<var name="menuItem" value="Active" />
 		</execute>
 
-		<if>
-			<condition function="IsElementPresent" locator1="ContentRow#ENTRY_CONTENT_ROW_1" />
-			<then>
-				<execute macro="PortletEntry#selectAll" />
+		<while>
+			<condition function="IsElementPresent" locator1="ContentRow#ENTRY_CONTENT_ROW_NUMBER">
+				<var name="key_rowNumber" value="2" />
+			</condition>
 
-				<execute function="AssertClickNoError" locator1="Button#DEACTIVATE" value1="Deactivate" />
+			<then>
+				<execute function="Click#waitForMenuToggleJSClick" locator1="ContentRow#ENTRY_CONTENT_ROW_NUMBER_ELLIPSIS">
+					<var name="key_rowNumber" value="2" />
+				</execute>
+
+				<execute macro="MenuItem#clickNoError">
+					<var name="menuItem" value="Deactivate" />
+				</execute>
 
 				<execute function="AssertConfirm" value1="Are you sure you want to deactivate the selected users?" />
-
-				<execute macro="Alert#viewSuccessMessage" />
 			</then>
-		</if>
+		</while>
 
 		<execute function="Click" locator1="Dropdown#FILTER_AND_ORDER" />
 

--- a/test.properties
+++ b/test.properties
@@ -1417,7 +1417,7 @@
         modules-unit-jdk8,\
         modules-unit-project-templates-jdk8,\
         portal-frontend-js-jdk8,\
-        #semantic-versioning-jdk8,\
+        semantic-versioning-jdk8,\
         service-builder-jdk8,\
         unit-jdk8
 


### PR DESCRIPTION
Announcements uses the Delete Icon instead of the Trash Icon.

**Special Note:** After talking to my trainer @gregory-bretall, we think that the Delete Icon can potentially be removed since users are also able to select "Delete" after clicking on the Actions Icon. However, after double checking all the source files, it seems like there is always an additional Delete Icon (most likely for shortcut purposes) even when "Delete" can be selected in the drop down menu of the Actions Icon. Thus, the Delete Icon has been kept in this Pull Request in order to keep the UI consistent.