### PR TITLE
LPS-85564 Add scrollIntoView in message boards for ios browsers

### DIFF
--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_message.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_message.jsp
@@ -77,6 +77,12 @@ MBBreadcrumbUtil.addPortletBreadcrumbEntries(message, request, renderResponse);
 		window[editorName].focus();
 
 		Liferay.Util.toggleDisabled('#<portlet:namespace />replyMessageButton' + messageId, true);
+
+		if (/iPad|iPhone|iPod/.test(navigator.userAgent)) {
+			var editor = '<portlet:namespace />addReplyToMessage' + messageId;
+
+			document.getElementById(editor).scrollIntoView(true);
+		}
 	}
 
 	function <portlet:namespace />hideReplyMessage(messageId) {


### PR DESCRIPTION
In message boards, when replying to a thread the screen does not focus on the reply editor when using an ios device. This is due to the fact that ios devices does not work well with `.focus()`. In order to get focus on the editor I made sure the device is an ios and then used `scrollIntoView(true)` to move the screen to the correct location.

If there are any questions or comments please let me know.
Thank you.