### PR TITLE
LPS-85564 Focus message board element for ios devices

### DIFF
--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_message.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_message.jsp
@@ -76,7 +76,7 @@ MBBreadcrumbUtil.addPortletBreadcrumbEntries(message, request, renderResponse);
 		window[editorName].setHTML(quote);
 		window[editorName].focus();
 
-		if (/iPad|iPhone|iPod/.test(navigator.userAgent)) {
+		if (AUI().UA.ios) {
 			document.getElementById(editorName).focus();
 		}
 

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_message.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_message.jsp
@@ -76,6 +76,10 @@ MBBreadcrumbUtil.addPortletBreadcrumbEntries(message, request, renderResponse);
 		window[editorName].setHTML(quote);
 		window[editorName].focus();
 
+		if (/iPad|iPhone|iPod/.test(navigator.userAgent)) {
+			document.getElementById(editorName).focus();
+		}
+
 		Liferay.Util.toggleDisabled('#<portlet:namespace />replyMessageButton' + messageId, true);
 	}
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-85564

In message boards, when replying to a thread the screen does not focus on the reply editor when using an ios device. I found that focus() on ios works best when it is called on the element. This will scroll the page to the reply box and also open the keyboard. 

If there are any questions or comments, please let me know.
Thank you.