### PR TITLE
LPS-85966 add IE specific line break workaround

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-image-js-web/src/main/resources/META-INF/resources/ckeditor/plugins/adaptivemedia/plugin.js
+++ b/modules/apps/adaptive-media/adaptive-media-image-js-web/src/main/resources/META-INF/resources/ckeditor/plugins/adaptivemedia/plugin.js
@@ -124,7 +124,11 @@
 				editor.insertHtml(el.getOuterHtml());
 
 				if (isSelectionEmpty) {
-					editor.execCommand('enter');
+					if(AUI.Env.UA.ie >= 9){
+						editor.insertHtml(el.getOuterHtml() + ' <br> ');
+					}else {
+						editor.execCommand('enter');
+					}
 				}
 			}
 		}

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/itemselector/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/itemselector/plugin.js
@@ -399,7 +399,11 @@
 									editor.insertHtml('<img src="' + imageSrc + '">');
 
 									if (isSelectionEmpty) {
-										editor.execCommand('enter');
+										if(AUI.Env.UA.ie >= 9){
+											editor.insertHtml('<img src="' + imageSrc + '">' + ' <br> ');
+										}else {
+											editor.execCommand('enter');
+										}
 									}
 
 									editor.focus();


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-85966

In IE11, without this change there is no new line.  Adapting the code to create a new line still places it above the image and I couldn't find an editor command to move the cursor to the end so for IE we're explicitly adding a <br> tag after the image.