### PR TITLE
LPS-84657 Add setPosition to getToolbarsStylesSelectionsImageJSONObject

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/java/com/liferay/frontend/editor/alloyeditor/web/internal/editor/configuration/AlloyEditorConfigContributor.java
+++ b/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/java/com/liferay/frontend/editor/alloyeditor/web/internal/editor/configuration/AlloyEditorConfigContributor.java
@@ -227,6 +227,7 @@ public class AlloyEditorConfigContributor
 			toJSONArray(
 				"['imageLeft', 'imageCenter', 'imageRight', 'linkBrowse']"));
 		jsonObject.put("name", "image");
+		jsonObject.put("setPosition", "AlloyEditor.SelectionSetPosition.image");
 		jsonObject.put("test", "AlloyEditor.SelectionTest.image");
 
 		return jsonObject;


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-84657

Additional commit is required to fix this issue. 
The AlloyEditor toolbar does not follow the image when it is being aligned. This is due to the current implementation that is tracking the last position the user clicked. By adding setPosition to getToolbarsStylesSelectionsImageJSONObject, it will center the toolbar on the image instead of where the user clicked. The previous commits worked on setting the toolbar so it would not overflow off the browser.

If you have any questions or comments, please let me know.
Thank you.