### PR TITLE
LPS-86369 

### DIFF
--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/servlet/FriendlyURLServlet.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/servlet/FriendlyURLServlet.java
@@ -127,7 +127,7 @@ public class FriendlyURLServlet extends HttpServlet {
 			throw new NoSuchGroupException(sb.toString());
 		}
 
-		Locale locale = portal.getLocale(request);
+		Locale locale = portal.getLocale(request, null, false);
 
 		SiteFriendlyURL siteFriendlyURL =
 			siteFriendlyURLLocalService.fetchSiteFriendlyURL(

--- a/portal-impl/src/com/liferay/portal/language/LanguageImpl.java
+++ b/portal-impl/src/com/liferay/portal/language/LanguageImpl.java
@@ -1033,7 +1033,7 @@ public class LanguageImpl implements Language, Serializable {
 			}
 		}
 
-		Locale locale = PortalUtil.getLocale(request);
+		Locale locale = PortalUtil.getLocale(request, null, false);
 
 		return getLanguageId(locale);
 	}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-86369
https://issues.liferay.com/browse/LPP-31743

After working with Minhchau, we were able to come up with an alternative fix (the original temporary workaround can be found in this [PR](https://github.com/gregory-bretall/liferay-portal/pull/115)) for the issues described by the tickets above where certain language keys are not getting translated to the correct language on the initial render if the default language for the site is changed to something that is not English. The original call to the `PortalImpl.getLocale(request)` method inside `FriendlyURLServlet.java` and `LanguageImpl.java` will cause the wrong locale to be set in the request's locale attribute as seen [here](https://github.com/liferay/liferay-portal/blob/master/portal-impl/src/com/liferay/portal/util/PortalImpl.java#L3394).

By changing the call to `PortalImpl.getLocale(request)` to `PortalImpl.getLocale(request, null, false)`, we are preventing the incorrect locale to be set in the request's locale attribute, and the liferay-ui:message tags will be able to retrieve the correct locale from the resource bundle (if the user has changed the default language of the site to something that is not English) by the time [this line](https://github.com/liferay/liferay-portal/blob/master/util-taglib/src/com/liferay/taglib/ui/MessageTag.java#L60) is getting called.

After discussing with Minhchau, we came to the conclusion that while this change can potentially affect performance (since a call to `PortalImpl.getLocale(request, null, false)` is definitely more costly compared to a call to `PortalImpl.getLocale(request)`) , this is the best solution we are able to come up with for this issue.
