### PR TITLE
LPS-86593 align rss-time-interval

### DIFF
--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/css/main.scss
@@ -395,7 +395,7 @@
 }
 
 .rss-time-interval {
-	margin-left: 2em;
+	margin-left: 0;
 	margin-top: -1em;
 }
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-86593

Master and 71x fix because the styling has changed -- with `fieldset { width:100% }` margin-left is no longer needed for alignment.

I chose to leave 0 instead of deleting the declaration to be more explicit and also I removed the units because I think that's the preferred styling.