### PR TITLE
LPS-84810

### DIFF
--- a/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/configuration/SearchEngineHelperConfiguration.java
+++ b/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/configuration/SearchEngineHelperConfiguration.java
@@ -32,7 +32,7 @@ import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClass
 public interface SearchEngineHelperConfiguration {
 
 	@Meta.AD(
-		deflt = "com.liferay.asset.kernel.model.AssetCategory|com.liferay.asset.kernel.model.AssetEntry|com.liferay.asset.kernel.model.AssetVocabulary|com.liferay.calendar.model.Calendar|com.liferay.configuration.admin.web.model.ConfigurationModel|com.liferay.document.library.kernel.model.DLFileEntryMetadata|com.liferay.exportimport.kernel.model.ExportImportConfiguration|com.liferay.message.boards.model.MBThread|com.liferay.portal.kernel.model.Contact|com.liferay.portal.kernel.model.Organization|com.liferay.portal.kernel.model.UserGroup|com.liferay.portal.kernel.plugin.PluginPackage|com.liferay.trash.model.TrashEntry|com.liferay.wiki.model.WikiNode",
+		deflt = "com.liferay.asset.kernel.model.AssetCategory|com.liferay.asset.kernel.model.AssetEntry|com.liferay.asset.kernel.model.AssetTag|com.liferay.asset.kernel.model.AssetVocabulary|com.liferay.calendar.model.Calendar|com.liferay.configuration.admin.web.model.ConfigurationModel|com.liferay.document.library.kernel.model.DLFileEntryMetadata|com.liferay.exportimport.kernel.model.ExportImportConfiguration|com.liferay.message.boards.model.MBThread|com.liferay.portal.kernel.model.Contact|com.liferay.portal.kernel.model.Organization|com.liferay.portal.kernel.model.UserGroup|com.liferay.portal.kernel.plugin.PluginPackage|com.liferay.trash.model.TrashEntry|com.liferay.wiki.model.WikiNode",
 		name = "excluded-entry-class-names", required = false
 	)
 	public String[] excludedEntryClassNames();


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-84810
https://issues.liferay.com/browse/LPP-31947

After working with Eric Yan and Bryan Engler, we have verified that `com.liferay.asset.kernel.model.AssetTag` has been completely removed from asset.xml as seen in [this commit](https://github.com/liferay/liferay-portal/commit/cf59bf41ef421ec46746d9a7827b64974a79aaf2#diff-824ecf5388b3d31996d22800a2c89385). In addition, the commit messages in this [link](https://github.com/brianchandotcom/liferay-portal/compare/7bfa72fef5...62a5fb3691) confirms that the AssetTags don't have individual permissions so we shouldn't be checking them.

In order to prevent the `NoSuchResourceActionException` from being thrown by `com.liferay.asset.kernel.model.AssetTag#VIEW`, `com.liferay.asset.kernel.model.AssetTag` has been added to the excludedEntryClassNames similar to [the fix for LPS-75264](https://github.com/brianchandotcom/liferay-portal/pull/52462/commits/8fc9e30e41d3e7761765471eb96cc1bad7ed5ef1).

I have discussed my current solution with Eric and Bryan, and I have also been told that I should not worry about the integration/unit tests described by the comment in LPS-84810. :')