### PR TITLE
LPS-84810

### DIFF
--- a/modules/apps/asset/asset-tags-service/src/main/java/com/liferay/asset/tags/internal/search/AssetTagIndexer.java
+++ b/modules/apps/asset/asset-tags-service/src/main/java/com/liferay/asset/tags/internal/search/AssetTagIndexer.java
@@ -54,7 +54,7 @@ public class AssetTagIndexer extends BaseIndexer<AssetTag> {
 		setDefaultSelectedFieldNames(
 			Field.COMPANY_ID, Field.GROUP_ID, Field.UID);
 		setFilterSearch(true);
-		setPermissionAware(true);
+		setPermissionAware(false);
 	}
 
 	@Override


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-84810
https://issues.liferay.com/browse/LPP-31947

This is the updated fix for [LPS-84810](https://issues.liferay.com/browse/LPS-84810) while addressing the new scenario described by [this comment in LPP-31947](https://issues.liferay.com/browse/LPP-31947?focusedCommentId=1611718&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-1611718). The PermissionAware for AssetTagIndexer has been set to false because Asset Tags do not have permissions, as explained by [this comment from the previous PR](https://github.com/gregory-bretall/liferay-portal/pull/121#issue-226746655).

**Additional Notes:**
- I was told to not worry about the integration/unit tests described by [this comment in LPS-84810](https://issues.liferay.com/browse/LPS-84810?focusedCommentId=1521917&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-1521917). :')
- I have discussed this solution with Bryan Engler. :smile: 