### PR TITLE
LPS-87474 Fix blue box on image center alignment IE11

### DIFF
--- a/modules/apps/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/portal/_editor_alloy.scss
+++ b/modules/apps/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/portal/_editor_alloy.scss
@@ -128,6 +128,28 @@
 	.alloy-editor-wrapper {
 		padding-top: 44px;
 
+		.cke_widget_wrapper.cke_widget_focused {
+			> .cke_widget_element,
+			> .cke_widget_wrapper,
+			> .cke_widget_editable.cke_widget_editable_focused {
+				outline: none;
+			}
+
+			.cke_image_resizer_wrapper {
+				outline: 2px solid #ace;
+			}
+
+			img[class="cke_widget_element"] {
+				outline: 2px solid #ace;
+			}
+		}
+
+		.cke_widget_wrapper:hover {
+			.cke_widget_element {
+				outline: none;
+			}
+		}
+
 		.lfr-source-editor {
 			display: none;
 		}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-87474

> Issue: When center aligning an image in alloy editor in IE11, the selected image obtains a border that spans the entire width of the editor, as opposed to just around the image. The issue resides in the editor which changed the contents of the class that contains the image to containing another wrapper that contains the image.

> Solution: Write custom css to override current outline styling with appropriate outlining on the relevant classes.

Test result : https://github.com/SpencerWoo/liferay-portal/pull/26#issuecomment-440105356