### PR TITLE
LPS-87098 IE11 change image span to inline to prevent defocus

### DIFF
--- a/modules/apps/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/portal/_editor_alloy.scss
+++ b/modules/apps/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/portal/_editor_alloy.scss
@@ -109,6 +109,10 @@
 			}
 		}
 
+		.cke_widget_inline {
+			display: inline;
+		}
+
 		.cke_widget_wrapper {
 			max-width: 100%;
 		}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-87098

In IE11, adding an image in AlloyEditor will result the image in being surrounded in a span. This span comes from ckeditor and contains `.cke_widget_inline` which has `display: inline-block`. When the image is selected and then a left arrow button is pressed, the editor will defocus. I have found that the parent container cannot be focused if the element contains `display: inline-block` in IE11. I was able to find this in [Microsoft Support](https://support.microsoft.com/en-us/help/4088339/parent-container-can-not-get-focus-if-display-inline-block-style-used). This issue only affects images in IE11.

In order to fix this issue, I changed the css for the span to `inline`. This way the issue will not be present. This will not affect any aspect of the image itself and will function normally.

Please let me know if there are any questions or comments.
Thank you.