### PR TITLE
LPS-87524 Replace .includes() for IE11

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/search_container_select.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/search_container_select.js
@@ -212,7 +212,7 @@ AUI.add(
 							function(commonActions, elementActions) {
 								return commonActions.filter(
 									function(action) {
-										return elementActions.includes(action);
+										return elementActions.indexOf(action) !== -1;
 									}
 								);
 							},


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-87524

IE11 does not support `includes()`. This is being used ot bring up the management bar to select content. By changing it to indexOf() and checking to see if it exist we can produce the same behavior.

Let me know if there are any questions or comments.
Thank you.