### PR TITLE
LPS-88170 Changed variables and created check for bad column variables

### DIFF
--- a/modules/util/portal-tools-service-builder/src/main/java/com/liferay/portal/tools/service/builder/ServiceBuilder.java
+++ b/modules/util/portal-tools-service-builder/src/main/java/com/liferay/portal/tools/service/builder/ServiceBuilder.java
@@ -506,6 +506,8 @@ public class ServiceBuilder {
 			"bad_alias_names", _tplBadAliasNames);
 		_tplBadColumnNames = _getTplProperty(
 			"bad_column_names", _tplBadColumnNames);
+		_tplBadColumnVariables = _getTplProperty(
+			"bad_column_variables", _tplBadColumnVariables);
 		_tplBadTableNames = _getTplProperty(
 			"bad_table_names", _tplBadTableNames);
 		_tplBlobModel = _getTplProperty("blob_model", _tplBlobModel);
@@ -589,6 +591,7 @@ public class ServiceBuilder {
 			_badTableNames = _readLines(_tplBadTableNames);
 			_badAliasNames = _readLines(_tplBadAliasNames);
 			_badColumnNames = _readLines(_tplBadColumnNames);
+			_badColumnVariables = _readLines(_tplBadColumnVariables);
 
 			_commercialPlugin = _isCommercialPlugin(Paths.get("."));
 
@@ -5430,6 +5433,11 @@ public class ServiceBuilder {
 			if (Validator.isNull(columnDBName)) {
 				columnDBName = columnName;
 
+				if (_badColumnVariables.contains(columnName)) {
+					throw new IllegalArgumentException(
+						"Unable to use " + columnName + " for a column name");
+				}
+
 				if (_badColumnNames.contains(columnName)) {
 					columnDBName += StringPool.UNDERLINE;
 				}
@@ -6861,6 +6869,7 @@ public class ServiceBuilder {
 	private boolean _autoNamespaceTables;
 	private Set<String> _badAliasNames;
 	private Set<String> _badColumnNames;
+	private Set<String> _badColumnVariables;
 	private Set<String> _badTableNames;
 	private String _beanLocatorUtil;
 	private boolean _build;
@@ -6902,6 +6911,8 @@ public class ServiceBuilder {
 	private String _testOutputPath;
 	private String _tplBadAliasNames = _TPL_ROOT + "bad_alias_names.txt";
 	private String _tplBadColumnNames = _TPL_ROOT + "bad_column_names.txt";
+	private String _tplBadColumnVariables =
+		_TPL_ROOT + "bad_column_variables.txt";
 	private String _tplBadTableNames = _TPL_ROOT + "bad_table_names.txt";
 	private String _tplBaseUADAnonymizer =
 		_TPL_ROOT + "base_uad_anonymizer.ftl";

--- a/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/bad_column_variables.txt
+++ b/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/bad_column_variables.txt
@@ -1,0 +1,7 @@
+oValue
+oValues
+q
+query
+qList
+sql
+sqlQuery

--- a/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/persistence_impl_finder_find.ftl
+++ b/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/persistence_impl_finder_find.ftl
@@ -580,17 +580,17 @@ that may or may not be enforced with a unique index at the database level. Case
 			<@finderQPos />
 
 			if (orderByComparator != null) {
-				Object[] values = orderByComparator.getOrderByConditionValues(${entity.varName});
+				Object[] oValues = orderByComparator.getOrderByConditionValues(${entity.varName});
 
-				for (Object value : values) {
-					qPos.add(value);
+				for (Object oValue : oValues) {
+					qPos.add(oValue);
 				}
 			}
 
-			List<${entity.name}> list = q.list();
+			List<${entity.name}> qList = q.list();
 
-			if (list.size() == 2) {
-				return list.get(1);
+			if (qList.size() == 2) {
+				return qList.get(1);
 			}
 			else {
 				return null;
@@ -912,17 +912,17 @@ that may or may not be enforced with a unique index at the database level. Case
 					<@finderQPos />
 
 					if (orderByComparator != null) {
-						Object[] values = orderByComparator.getOrderByConditionValues(${entity.varName});
+						Object[] oValues = orderByComparator.getOrderByConditionValues(${entity.varName});
 
-						for (Object value : values) {
-							qPos.add(value);
+						for (Object oValue : oValues) {
+							qPos.add(oValue);
 						}
 					}
 
-					List<${entity.name}> list = q.list();
+					List<${entity.name}> qList = q.list();
 
-					if (list.size() == 2) {
-						return list.get(1);
+					if (qList.size() == 2) {
+						return qList.get(1);
 					}
 					else {
 						return null;
@@ -1049,17 +1049,17 @@ that may or may not be enforced with a unique index at the database level. Case
 					<@finderQPos />
 
 					if (orderByComparator != null) {
-						Object[] values = orderByComparator.getOrderByConditionValues(${entity.varName});
+						Object[] oValues = orderByComparator.getOrderByConditionValues(${entity.varName});
 
-						for (Object value : values) {
-							qPos.add(value);
+						for (Object oValue : oValues) {
+							qPos.add(oValue);
 						}
 					}
 
-					List<${entity.name}> list = q.list();
+					List<${entity.name}> qList = q.list();
 
-					if (list.size() == 2) {
-						return list.get(1);
+					if (qList.size() == 2) {
+						return qList.get(1);
 					}
 					else {
 						return null;


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-88170

Service Builder runs into syntax errors if the user uses a column name in the service.xml that is already defined in the ftl. In order to fix this issue I did two things:

1. Changed the variable names in the ftl to make them uncommon. I did this so that users who are using these variables and are passed the design stage will not have to update their database. The variable names can be generalized even more if seen fit.

2. Added a list `bad_column_variables.txt` that will check the column names and notify the user that the name they are using is not acceptable. These words were picked from the generated methods that will result in syntax errors.

Testing:
1. Add the changes and deploy `portal-tools-service-builder`
2. Go to `portal-impl/src/com/liferay/counter/service.xml` and add the following:
```
<column name="value" type="String" />

<finder name="test" return-type="Collection">
    <finder-column name="value" />
</finder>
```
You can also change the name of the column to test other options. Make sure to also change finder-column name.
3. In `portal-impl`, run the following:
`ant build-service -Dservice.file=${PWD}/src/com/liferay/counter/service.xml`
This will build the services for counter. At this stage, if the user entered an invalid name for column an error message will appear.
4. If all is successful run `ant deploy` to deploy the changes and see if there are any errors for counter.


Please let me know if there are any questions or comments.
Thank you.