### PR TITLE
Lps 87985d

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/date/date_field.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/date/date_field.js
@@ -11,6 +11,18 @@ AUI.add(
 			dateFormat = customDateFormat;
 		}
 
+		var dateDelimiter = '/';
+		var endDelimiter = false;
+		if (dateFormat.indexOf('.') != -1) {
+			dateDelimiter = '.';
+			if (dateFormat.lastIndexOf('.') == dateFormat.length - 1) {
+				endDelimiter = true;
+			}
+		}
+		if (dateFormat.indexOf('-') != -1) {
+			dateDelimiter = '-';
+		}
+
 		var DateField = A.Component.create(
 			{
 				ATTRS: {
@@ -90,7 +102,7 @@ AUI.add(
 
 						var dateMask = [];
 
-						var items = mask.split('/');
+						var items = mask.split(dateDelimiter);
 
 						items.forEach(
 							function(item, index) {
@@ -101,11 +113,15 @@ AUI.add(
 									dateMask.push(/\d/, /\d/);
 								}
 
-								if (index < (items.length - 1)) {
-									dateMask.push('/');
+								if (index < 2) {
+									dateMask.push(dateDelimiter);
 								}
 							}
 						);
+
+						if (endDelimiter) {
+							dateMask.push(dateDelimiter);
+						}
 
 						return dateMask;
 					},

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/date/date_field.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/date/date_field.js
@@ -3,6 +3,14 @@ AUI.add(
 	function(A) {
 		var isArray = Array.isArray;
 
+		var langId = Liferay.ThemeDisplay.getLanguageId().replace('_', '-');
+		var customDateFormat = A.Intl.get('datatype-date-format', 'x', langId);
+		var dateFormat = Liferay.AUI.getDateFormat();
+
+		if (customDateFormat) {
+			dateFormat = customDateFormat;
+		}
+
 		var DateField = A.Component.create(
 			{
 				ATTRS: {
@@ -11,7 +19,7 @@ AUI.add(
 					},
 
 					mask: {
-						value: Liferay.AUI.getDateFormat()
+						value: dateFormat
 					},
 
 					predefinedValue: {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/date/date_field.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/date/date_field.js
@@ -3,8 +3,8 @@ AUI.add(
 	function(A) {
 		var isArray = Array.isArray;
 
-		var langId = Liferay.ThemeDisplay.getLanguageId().replace('_', '-');
-		var customDateFormat = A.Intl.get('datatype-date-format', 'x', langId);
+		var languageId = Liferay.ThemeDisplay.getLanguageId().replace('_', '-');
+		var customDateFormat = A.Intl.get('datatype-date-format', 'x', languageId);
 		var dateFormat = Liferay.AUI.getDateFormat();
 
 		if (customDateFormat) {
@@ -13,12 +13,15 @@ AUI.add(
 
 		var dateDelimiter = '/';
 		var endDelimiter = false;
+
 		if (dateFormat.indexOf('.') != -1) {
 			dateDelimiter = '.';
+
 			if (dateFormat.lastIndexOf('.') == dateFormat.length - 1) {
 				endDelimiter = true;
 			}
 		}
+
 		if (dateFormat.indexOf('-') != -1) {
 			dateDelimiter = '-';
 		}

--- a/portal-web/docroot/html/common/themes/top_js.jspf
+++ b/portal-web/docroot/html/common/themes/top_js.jspf
@@ -589,15 +589,48 @@ private static String _getDateFormatPattern(Locale locale) {
 		SimpleDateFormat simpleDateFormat = (SimpleDateFormat)DateFormat.getDateInstance(DateFormat.SHORT, locale);
 
 		dateFormatPattern = simpleDateFormat.toPattern();
+		String lowerCaseDFP = StringUtil.toLowerCase(dateFormatPattern);
 
-		if (dateFormatPattern.indexOf("y") == 0) {
-			dateFormatPattern = "%Y/%m/%d";
+		boolean endDelimiter = false;
+		char dateFormatSymbol = CharPool.FORWARD_SLASH;
+
+		for (char dateDelimiter : _DATE_DELIMITERS) {
+			if (lowerCaseDFP.indexOf(dateDelimiter) != -1) {
+				dateFormatSymbol = dateDelimiter;
+
+				if (lowerCaseDFP.lastIndexOf(dateDelimiter) ==
+					lowerCaseDFP.length() - 1) {
+
+					endDelimiter = true;
+				}
+			}
 		}
-		else if (dateFormatPattern.indexOf("d") == 0) {
-			dateFormatPattern = "%d/%m/%Y";
+
+		int dayOrder = lowerCaseDFP.indexOf("d");
+		int monthOrder = lowerCaseDFP.indexOf("m");
+		int yearOrder = lowerCaseDFP.indexOf("y");
+
+		if ((yearOrder < dayOrder) && (yearOrder < monthOrder)) {
+			dateFormatPattern =
+				"%y" + dateFormatSymbol + "%m" + dateFormatSymbol + "%d";
+		}
+		else if (dayOrder < monthOrder) {
+			dateFormatPattern =
+				"%d" + dateFormatSymbol + "%m" + dateFormatSymbol + "%y";
 		}
 		else {
-			dateFormatPattern = "%m/%d/%Y";
+			dateFormatPattern =
+				"%m" + dateFormatSymbol + "%d" + dateFormatSymbol + "%y";
+		}
+
+		if (endDelimiter) {
+			dateFormatPattern += dateFormatSymbol;
+		}
+
+		boolean fullYear = lowerCaseDFP.contains("yyyy");
+
+		if (fullYear) {
+			dateFormatPattern.replace("y", "Y");
 		}
 
 		_dateFormatPatterns.put(languageId, dateFormatPattern);
@@ -629,6 +662,10 @@ private static boolean _isAnalyticsTrackingEnabled(String liferayAnalyticsKey, S
 
 	return false;
 }
+
+private static final char[] _DATE_DELIMITERS = {
+	CharPool.DASH, CharPool.FORWARD_SLASH, CharPool.PERIOD
+};
 
 private static final Map<String, String> _dateFormatPatterns = new ConcurrentHashMap<>();
 %>

--- a/portal-web/docroot/html/common/themes/top_js.jspf
+++ b/portal-web/docroot/html/common/themes/top_js.jspf
@@ -586,48 +586,45 @@ private static String _getDateFormatPattern(Locale locale) {
 	String dateFormatPattern = _dateFormatPatterns.get(languageId);
 
 	if (dateFormatPattern == null) {
+		boolean endDelimiter = false;
+
+		String delimiterString = StringPool.FORWARD_SLASH;
+
 		SimpleDateFormat simpleDateFormat = (SimpleDateFormat)DateFormat.getDateInstance(DateFormat.SHORT, locale);
 
 		dateFormatPattern = simpleDateFormat.toPattern();
-		String lowerCaseDFP = StringUtil.toLowerCase(dateFormatPattern);
-
-		boolean endDelimiter = false;
-		char dateFormatSymbol = CharPool.FORWARD_SLASH;
 
 		for (char dateDelimiter : _DATE_DELIMITERS) {
-			if (lowerCaseDFP.indexOf(dateDelimiter) != -1) {
-				dateFormatSymbol = dateDelimiter;
+			if (dateFormatPattern.indexOf(dateDelimiter) != -1) {
+				delimiterString = String.valueOf(dateDelimiter);
 
-				if (lowerCaseDFP.lastIndexOf(dateDelimiter) ==
-					lowerCaseDFP.length() - 1) {
+				endDelimiter = dateFormatPattern.endsWith(delimiterString);
 
-					endDelimiter = true;
-				}
+				break;
 			}
 		}
 
-		int dayOrder = lowerCaseDFP.indexOf("d");
-		int monthOrder = lowerCaseDFP.indexOf("m");
-		int yearOrder = lowerCaseDFP.indexOf("y");
+		dateFormatPattern = StringUtil.toLowerCase(dateFormatPattern);
+
+		int dayOrder = dateFormatPattern.indexOf('d');
+		int monthOrder = dateFormatPattern.indexOf('m');
+		int yearOrder = dateFormatPattern.indexOf('y');
 
 		if ((yearOrder < dayOrder) && (yearOrder < monthOrder)) {
-			dateFormatPattern =
-				"%y" + dateFormatSymbol + "%m" + dateFormatSymbol + "%d";
+			dateFormatPattern = StringBundler.concat("%y", delimiterString, "%m", delimiterString, "%d");
 		}
 		else if (dayOrder < monthOrder) {
-			dateFormatPattern =
-				"%d" + dateFormatSymbol + "%m" + dateFormatSymbol + "%y";
+			dateFormatPattern = StringBundler.concat("%d", delimiterString, "%m", delimiterString, "%y");
 		}
 		else {
-			dateFormatPattern =
-				"%m" + dateFormatSymbol + "%d" + dateFormatSymbol + "%y";
+			dateFormatPattern = StringBundler.concat("%m", delimiterString, "%d", delimiterString, "%y");
 		}
 
 		if (endDelimiter) {
-			dateFormatPattern += dateFormatSymbol;
+			dateFormatPattern += delimiterString;
 		}
 
-		boolean fullYear = lowerCaseDFP.contains("yyyy");
+		boolean fullYear = StringUtil.contains(dateFormatPattern, "yyyy");
 
 		if (fullYear) {
 			dateFormatPattern.replace("y", "Y");

--- a/portal-web/docroot/html/common/themes/top_js.jspf
+++ b/portal-web/docroot/html/common/themes/top_js.jspf
@@ -604,10 +604,8 @@ private static String _getDateFormatPattern(Locale locale) {
 			}
 		}
 
-		dateFormatPattern = StringUtil.toLowerCase(dateFormatPattern);
-
 		int dayOrder = dateFormatPattern.indexOf('d');
-		int monthOrder = dateFormatPattern.indexOf('m');
+		int monthOrder = dateFormatPattern.indexOf('M');
 		int yearOrder = dateFormatPattern.indexOf('y');
 
 		if ((yearOrder < dayOrder) && (yearOrder < monthOrder)) {


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-87985

@ricky-pan 
> Issues:
Liferay form date-formats only support 3 orderings of mm/dd/yy, and the characters separating each field must be '/'s.
It also doesn't allow for users to deploy their own date-field format overrides.

>Solution:
In top_js.jspf, I edited how Liferay returns a DateFormat object given a locale. Previously, there were only 3, but using Java's DateFormats, there are 100+. The JS methods for parsing DateFormats uses strftime, which is in PHP, so I had to manually parse and process the dateformats for characters so that the front end can use it.
I added a check for custom date formats in date_field.js, which are loaded upon page loading, so that the custom format would override the default if it is present. It makes use of YUI's standard date formats.

Conversation : https://github.com/ricky-pan/liferay-portal/pull/1#issuecomment-445043155