### PR TITLE
LPS-88362 IE11 doesn't support includes()

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/search_container_select.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/search_container_select.js
@@ -212,7 +212,7 @@ AUI.add(
 							function(commonActions, elementActions) {
 								return commonActions.filter(
 									function(action) {
-										return elementActions.includes(action);
+										return (elementActions.indexOf(action) != -1);
 									}
 								);
 							},


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-88362

just an LPS, low priority.

tests : https://github.com/SpencerWoo/liferay-portal/pull/35#issuecomment-446410750