### PR TITLE
LPS-88560 guard groupIdNode against null

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
@@ -1365,7 +1365,7 @@ AUI.add(
 
 						var groupIdNode = A.one('#' + this.get('portletNamespace') + 'groupId');
 
-						var groupId = groupIdNode.getAttribute('value') || themeDisplay.getScopeGroupId();
+						var groupId = (groupIdNode && groupIdNode.getAttribute('value')) || themeDisplay.getScopeGroupId();
 
 						url.setParameter('eventName', 'selectContent');
 						url.setParameter('groupId', groupId);
@@ -1517,7 +1517,7 @@ AUI.add(
 
 							var groupIdNode = A.one('#' + this.get('portletNamespace') + 'groupId');
 
-							var groupId = groupIdNode.getAttribute('value') || themeDisplay.getScopeGroupId();
+							var groupId = (groupIdNode && groupIdNode.getAttribute('value')) || themeDisplay.getScopeGroupId();
 
 							var layoutsRoot = {
 								groupId: groupId,
@@ -1943,7 +1943,7 @@ AUI.add(
 
 						var groupIdNode = A.one('#' + this.get('portletNamespace') + 'groupId');
 
-						var groupId = groupIdNode.getAttribute('value') || themeDisplay.getScopeGroupId();
+						var groupId = (groupIdNode && groupIdNode.getAttribute('value')) || themeDisplay.getScopeGroupId();
 
 						var parentLayoutId = instance._currentParentLayoutId;
 
@@ -2184,7 +2184,7 @@ AUI.add(
 
 						var groupIdNode = A.one('#' + this.get('portletNamespace') + 'groupId');
 
-						var groupId = groupIdNode.getAttribute('value') || themeDisplay.getScopeGroupId();
+						var groupId = (groupIdNode && groupIdNode.getAttribute('value')) || themeDisplay.getScopeGroupId();
 
 						if (selectedLayout && selectedLayout.layoutId) {
 							instance._requestSiblingLayouts(


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-88560

Regression caused by https://issues.liferay.com/browse/LPS-88009 where groupIdNode can be null.