### PR TITLE
LPS-88702 - Revert LPS-86846 Change the favicon link to IE with only …

### DIFF
--- a/portal-web/docroot/html/common/themes/top_head.jsp
+++ b/portal-web/docroot/html/common/themes/top_head.jsp
@@ -20,7 +20,7 @@
 
 <liferay-util:dynamic-include key="/html/common/themes/top_head.jsp#pre" />
 
-<link href="<%= BrowserSnifferUtil.isIe(request) ? StringPool.BLANK : themeDisplay.getPathThemeImages() %>/<%= PropsValues.THEME_SHORTCUT_ICON %>" rel="icon" />
+<link href="<%= themeDisplay.getPathThemeImages() %>/<%= PropsValues.THEME_SHORTCUT_ICON %>" rel="icon" />
 
 <%-- Available Translations --%>
 


### PR DESCRIPTION
…/favicon.ico

https://issues.liferay.com/browse/LPS-88702

I am reverting [LPS-86846](https://issues.liferay.com/browse/LPS-86846) since this behavior makes it so the default favicon will always display for IE11. This is a problem since custom themes with new favicons will never display in IE11. The original issue was not reproducible in Master and so reverting will not cause any regression.

Testing:
If Master contains a Metaspace error preventing testing, adding these changes from LPS-86682 will resolve the issue.
https://github.com/shuyangzhou/liferay-portal/pull/7033/commits/2bc1d94fcf39c36885841f44243c4d6b4f0d057b

Please let me know if there are any questions or comments about this.
Thank you!
