### PR TITLE
LPS-88860 Remove draggable attribute in repeatable fields

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
@@ -3252,6 +3252,12 @@ AUI.add(
 							repeatableInstance.add(fieldContainer);
 						}
 
+						var fieldAttributes = fieldContainer._node.attributes;
+
+						if (fieldAttributes.draggable) {
+							fieldAttributes.removeNamedItem('draggable');
+						}
+
 						var drag = A.DD.DDM.getDrag(fieldContainer);
 
 						drag.addInvalid('.alloy-editor');


### PR DESCRIPTION
**High Priority**
https://issues.liferay.com/browse/LPS-88860

In IE11, Edge, firefox, and Safari, input cannot be selected if the parent contains `draggable="true"`. I was able to find this MS Edge ticket that was placed as won't fix: https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/10375756/. I believe this is the same issue for the other browsers.

A solution for this was to remove `draggable="true"` from the parent. Removing this will make these browsers selectable again and the drag and drop events will still be available. I have tested on the other browsers,Michael helped me test on Safari, and the fix resolves the issue.

Please let me know if there are any comments or questions about this.