### PR TITLE
LPS-89278 use full column tree view

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/cards_treeview/CardsTreeview.soy
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/cards_treeview/CardsTreeview.soy
@@ -63,7 +63,7 @@
 		{if $node}
 			<div class="treeview-node-wrapper{$node.expanded ? ' expanded' : ''}">
 				{let $nodeAttributes kind="attributes"}
-					class="treeview-node-main clearfix col-md-4
+					class="treeview-node-main clearfix col-md-12
 					{$node.children ? ' hasChildren' : ''}
 					{$node.disabled ? ' disabled' : ''}
 					{$node.selected ? ' selected' : ''}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-89278

As far as I can tell there is no spec in [lexicon ](https://lexiconcss.wedeploy.io/content/modals) for using 1/3 columns for treeview/menus in a modal.