### PR TITLE
LPS-89414 Do not print image twice for ie

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-image-js-web/src/main/resources/META-INF/resources/ckeditor/plugins/adaptivemedia/plugin.js
+++ b/modules/apps/adaptive-media/adaptive-media-image-js-web/src/main/resources/META-INF/resources/ckeditor/plugins/adaptivemedia/plugin.js
@@ -132,7 +132,7 @@
 
 				if (instance._isEmptySelection(editor)) {
 					if (IE9) {
-						editor.insertHtml(el.getOuterHtml() + ' <br /> ');
+						editor.insertHtml(' <br /> ');
 					}
 					else {
 						editor.execCommand('enter');

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/itemselector/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/itemselector/plugin.js
@@ -408,7 +408,7 @@
 
 									if (instance._isEmptySelection(editor)) {
 										if (IE9) {
-											editor.insertHtml('<img src="' + imageSrc + '">' + ' <br /> ');
+											editor.insertHtml(' <br /> ');
 										}
 										else {
 											editor.execCommand('enter');


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-89414

The image is being printed twice for IE browsers. This is fixed by removing the second insertion of the image when adding the break line.

Let me know if there are any questions or comments about this.
Thank you.