### PR TITLE
LPS-89592 use table-cell instead of table for IE11

### DIFF
--- a/modules/apps/portal-workflow/portal-workflow-task-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/portal-workflow/portal-workflow-task-web/src/main/resources/META-INF/resources/css/main.scss
@@ -336,7 +336,7 @@
 
 	.task-action-button {
 		bottom: 0;
-		display: table;
+		display: table-cell;
 		margin: 0;
 		padding: 1.5rem;
 		position: absolute;


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-89592

https://stackoverflow.com/questions/35327767/inconsistent-behavior-of-display-table-and-display-table-cell-in-different-bro

table-cell here implicitly creates the row and then does table-cell on the element -- this preserves the current behavior the best (at the moment it's all good), however anonymous table objects might not be the most stable going forward.

Personally don't think the risk is a problem but worth considering.  Additionally removing the display completely works but the UI spacing on the buttons then becomes slightly different.