### PR TITLE
LPS-89414 Add condition for AlloyEditor and CKEditor for images

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-image-js-web/src/main/resources/META-INF/resources/ckeditor/plugins/adaptivemedia/plugin.js
+++ b/modules/apps/adaptive-media/adaptive-media-image-js-web/src/main/resources/META-INF/resources/ckeditor/plugins/adaptivemedia/plugin.js
@@ -132,7 +132,7 @@
 
 				if (instance._isEmptySelection(editor)) {
 					if (IE9) {
-						editor.insertHtml('<br />');
+						editor.contextMenu ? editor.insertHtml('<br />') : editor.insertHtml(el.getOuterHtml() + '<br />');
 					}
 					else {
 						editor.execCommand('enter');

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/itemselector/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/itemselector/plugin.js
@@ -408,7 +408,7 @@
 
 									if (instance._isEmptySelection(editor)) {
 										if (IE9) {
-											editor.insertHtml('<br />');
+											editor.contextMenu ? editor.insertHtml('<br />') : editor.insertHtml('<img src="' + imageSrc + '"><br />');
 										}
 										else {
 											editor.execCommand('enter');


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-89414

Additional commit to fix regression in AlloyEditor not displaying the image. There needs to be a check on which editor is being used and add correct html. I am using `editor.contextMenu` since it is present in CKEditor and not in AlloyEditor. 

Let me know if there are any questions or comments about this.
Thank you!