### PR TITLE
LPS-91028 - Revert LPS-33951 Workaround for firefox location.hash une…

### DIFF
--- a/modules/apps/iframe/iframe-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/iframe/iframe-web/src/main/resources/META-INF/resources/view.jsp
@@ -41,12 +41,6 @@
 
 				var hash = document.location.hash.replace('#', '');
 
-				// LPS-33951
-
-				if (!A.UA.gecko) {
-					hash = A.QueryString.unescape(hash);
-				}
-
 				var hashObj = A.QueryString.parse(hash);
 
 				hash = hashObj['<portlet:namespace />'];
@@ -140,9 +134,7 @@
 					restore.attr('href', restoreHREF + '#' + hash);
 				}
 
-				// LPS-33951
-
-				location.hash = A.QueryString.escape(hash);
+				location.hash = hash;
 			},
 			['aui-base', 'querystring']
 		);


### PR DESCRIPTION
…scaping bug

https://issues.liferay.com/browse/LPS-91028

[LPS-33951](https://issues.liferay.com/browse/LPS-33951) was a workaround fix for firefox bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1093611
The firefox bug was later fixed and LPS-33951 is no longer needed. Now it causes an issue with the URL when the user navigates in the iframe. Reverting this commit will fix this issue.

Let me know if there are any questions or comments about this.
Thank you!