### PR TITLE
LPS-88649 Missing site sub name after enabled remote live

### DIFF
--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_header.jsp
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_header.jsp
@@ -92,10 +92,6 @@ PanelCategory panelCategory = siteAdministrationPanelCategoryDisplayContext.getP
 
 			<span class="site-name truncate-text">
 				<%= HtmlUtil.escape(siteAdministrationPanelCategoryDisplayContext.getGroupName()) %>
-
-				<c:if test="<%= siteAdministrationPanelCategoryDisplayContext.isShowStagingInfo() %>">
-					<span class="site-sub-name"> - <liferay-ui:message key="<%= siteAdministrationPanelCategoryDisplayContext.getStagingLabel() %>" /></span>
-				</c:if>
 			</span>
 
 			<c:if test="<%= siteAdministrationPanelCategoryDisplayContext.getNotificationsCount() > 0 %>">


### PR DESCRIPTION
The site-name display was missing a "Staging" text notifier. The staging team decided not to display as it was originally intended and so the decision to remove the whole span and leave it just as a site name. 
https://issues.liferay.com/browse/LPS-88649