### PR TITLE
LPS-90727 XSS Vulnerability in Control Panel

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -1968,7 +1968,8 @@ public class PortalImpl implements Portal {
 			WebKeys.CURRENT_COMPLETE_URL);
 
 		if (currentCompleteURL == null) {
-			currentCompleteURL = HttpUtil.getCompleteURL(request);
+			currentCompleteURL = HtmlUtil.escapeURL(
+				HttpUtil.getCompleteURL(request));
 
 			request.setAttribute(
 				WebKeys.CURRENT_COMPLETE_URL, currentCompleteURL);
@@ -1999,6 +2000,8 @@ public class PortalImpl implements Portal {
 
 				currentURL = currentURL.substring(
 					currentURL.indexOf(CharPool.SLASH));
+
+				currentURL = HtmlUtil.escapeURL(currentURL);
 			}
 		}
 


### PR DESCRIPTION
XSS vulnerability caused by javascript call before the query string. The escape happens on the string occurring after the domain and is then set as a safe URL attribute. The pop-up no longer occurs.

https://issues.liferay.com/browse/LPS-90727