### PR TITLE
LPS-88649 Missing site sub name after enabled remote live

### DIFF
--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_header.jsp
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_header.jsp
@@ -93,7 +93,7 @@ PanelCategory panelCategory = siteAdministrationPanelCategoryDisplayContext.getP
 			<span class="site-name truncate-text">
 				<%= HtmlUtil.escape(siteAdministrationPanelCategoryDisplayContext.getGroupName()) %>
 
-				<c:if test="<%= siteAdministrationPanelCategoryDisplayContext.isShowStagingInfo() %>">
+				<c:if test="<%= siteAdministrationPanelCategoryDisplayContext.isShowStagingInfo() && !siteAdministrationPanelCategoryDisplayContext.getGroup().isStagedRemotely() %>">
 					<span class="site-sub-name"> - <liferay-ui:message key="<%= siteAdministrationPanelCategoryDisplayContext.getStagingLabel() %>" /></span>
 				</c:if>
 			</span>


### PR DESCRIPTION
The previous pr removed the conditional and [moltam89#479](https://github.com/moltam89/liferay-portal/pull/479#issuecomment-469669105) (comment) is fixed with this added condition.

The fix is to modify the display the site-sub-name for remote staging, but keep the display of local staging. I added an additional condition that checks if the staging is remote. If it is remote staging, the site-sub-name would not be displayed and if it is local staging it would follow the existing behavior.

https://issues.liferay.com/browse/LPS-88649