### PR TITLE
LPS-91359 In workflow review of Web Content asset, the preview's white space is inconsistent with the rest of the menus

### DIFF
--- a/modules/apps/portal-workflow/portal-workflow-task-web/src/main/resources/META-INF/resources/view_content.jsp
+++ b/modules/apps/portal-workflow/portal-workflow-task-web/src/main/resources/META-INF/resources/view_content.jsp
@@ -37,32 +37,36 @@ portletDisplay.setURLBack(redirect);
 renderResponse.setTitle(title);
 %>
 
-<div class="card-horizontal main-content-card">
-	<div class="panel-body">
-		<c:if test="<%= assetEntry != null %>">
-			<div class="locale-actions">
-				<liferay-ui:language
-					formAction="<%= currentURL %>"
-					languageId="<%= languageId %>"
-					languageIds="<%= availableLanguageIds %>"
-				/>
+<div class="container-fluid-1280 main-content-body">
+	<div class="col-md-12 lfr-asset-column lfr-asset-column-details">
+		<div class="card-horizontal main-content-card">
+			<div class="panel-body">
+				<c:if test="<%= assetEntry != null %>">
+					<div class="locale-actions">
+						<liferay-ui:language
+							formAction="<%= currentURL %>"
+							languageId="<%= languageId %>"
+							languageIds="<%= availableLanguageIds %>"
+						/>
+					</div>
+
+					<liferay-asset:asset-display
+						assetEntry="<%= assetEntry %>"
+						assetRenderer="<%= assetRenderer %>"
+						assetRendererFactory="<%= assetRendererFactory %>"
+					/>
+				</c:if>
+
+				<%
+				String viewInContextURL = assetRenderer.getURLViewInContext(liferayPortletRequest, liferayPortletResponse, null);
+				%>
+
+				<c:if test="<%= viewInContextURL != null %>">
+					<div class="asset-more">
+						<aui:a href="<%= viewInContextURL %>"><liferay-ui:message key="view-in-context" /> &raquo;</aui:a>
+					</div>
+				</c:if>
 			</div>
-
-			<liferay-asset:asset-display
-				assetEntry="<%= assetEntry %>"
-				assetRenderer="<%= assetRenderer %>"
-				assetRendererFactory="<%= assetRendererFactory %>"
-			/>
-		</c:if>
-
-		<%
-		String viewInContextURL = assetRenderer.getURLViewInContext(liferayPortletRequest, liferayPortletResponse, null);
-		%>
-
-		<c:if test="<%= viewInContextURL != null %>">
-			<div class="asset-more">
-				<aui:a href="<%= viewInContextURL %>"><liferay-ui:message key="view-in-context" /> &raquo;</aui:a>
-			</div>
-		</c:if>
+		</div>
 	</div>
 </div>


### PR DESCRIPTION
The issue is that the portlet's white space is inconsistent when switching screens from the preview to the review. I added two <div> elements to mimic the style of the previous portlet screen. This attaches margin and padding attributes to make the white spacing consistent. 

https://issues.liferay.com/browse/LPS-91359