### PR TITLE
LPS-91578 If a Private Page is present, Public Page content defaults to Viewable by Site Member

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_article.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_article.jsp
@@ -22,6 +22,8 @@ JournalArticle article = journalDisplayContext.getArticle();
 JournalEditArticleDisplayContext journalEditArticleDisplayContext = new JournalEditArticleDisplayContext(request, liferayPortletResponse, article);
 
 long classNameId = ParamUtil.getLong(request, "classNameId");
+
+themeDisplay.setRefererPlid(journalEditArticleDisplayContext.getReferringPlid());
 %>
 
 <aui:model-context bean="<%= article %>" model="<%= JournalArticle.class %>" />

--- a/modules/apps/polls/polls-service/src/main/java/com/liferay/polls/internal/exportimport/data/handler/PollsQuestionStagedModelDataHandler.java
+++ b/modules/apps/polls/polls-service/src/main/java/com/liferay/polls/internal/exportimport/data/handler/PollsQuestionStagedModelDataHandler.java
@@ -19,7 +19,9 @@ import com.liferay.exportimport.kernel.lar.ExportImportPathUtil;
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
 import com.liferay.exportimport.kernel.lar.StagedModelDataHandler;
 import com.liferay.exportimport.kernel.lar.StagedModelModifiedDateComparator;
+import com.liferay.polls.model.PollsChoice;
 import com.liferay.polls.model.PollsQuestion;
+import com.liferay.polls.model.PollsVote;
 import com.liferay.polls.service.PollsQuestionLocalService;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -103,6 +105,27 @@ public class PollsQuestionStagedModelDataHandler
 		portletDataContext.addClassedModel(
 			questionElement, ExportImportPathUtil.getModelPath(question),
 			question);
+
+		for (PollsChoice choice : question.getChoices()) {
+			Element choiceElement = portletDataContext.getExportDataElement(
+				choice);
+
+			portletDataContext.addClassedModel(
+				choiceElement, ExportImportPathUtil.getModelPath(choice),
+				choice);
+		}
+
+		if (portletDataContext.getBooleanParameter(
+				PollsPortletDataHandler.NAMESPACE, "votes")) {
+
+			for (PollsVote vote : question.getVotes()) {
+				Element voteElement = portletDataContext.getExportDataElement(
+					vote);
+
+				portletDataContext.addClassedModel(
+					voteElement, ExportImportPathUtil.getModelPath(vote), vote);
+			}
+		}
 	}
 
 	@Override

--- a/modules/apps/polls/polls-service/src/main/java/com/liferay/polls/internal/exportimport/data/handler/PollsQuestionStagedModelDataHandler.java
+++ b/modules/apps/polls/polls-service/src/main/java/com/liferay/polls/internal/exportimport/data/handler/PollsQuestionStagedModelDataHandler.java
@@ -107,20 +107,23 @@ public class PollsQuestionStagedModelDataHandler
 			question);
 
 		for (PollsChoice choice : question.getChoices()) {
-			Element element = portletDataContext.getExportDataElement(choice);
+			Element choiceElement = portletDataContext.getExportDataElement(
+				choice);
 
 			portletDataContext.addClassedModel(
-				element, ExportImportPathUtil.getModelPath(choice), choice);
+				choiceElement, ExportImportPathUtil.getModelPath(choice),
+				choice);
 		}
 
 		if (portletDataContext.getBooleanParameter(
 				PollsPortletDataHandler.NAMESPACE, "votes")) {
 
 			for (PollsVote vote : question.getVotes()) {
-				Element element = portletDataContext.getExportDataElement(vote);
+				Element voteElement = portletDataContext.getExportDataElement(
+					vote);
 
 				portletDataContext.addClassedModel(
-					element, ExportImportPathUtil.getModelPath(vote), vote);
+					voteElement, ExportImportPathUtil.getModelPath(vote), vote);
 			}
 		}
 	}

--- a/modules/apps/polls/polls-service/src/main/java/com/liferay/polls/internal/exportimport/data/handler/PollsQuestionStagedModelDataHandler.java
+++ b/modules/apps/polls/polls-service/src/main/java/com/liferay/polls/internal/exportimport/data/handler/PollsQuestionStagedModelDataHandler.java
@@ -107,23 +107,20 @@ public class PollsQuestionStagedModelDataHandler
 			question);
 
 		for (PollsChoice choice : question.getChoices()) {
-			Element choiceElement = portletDataContext.getExportDataElement(
-				choice);
+			Element element = portletDataContext.getExportDataElement(choice);
 
 			portletDataContext.addClassedModel(
-				choiceElement, ExportImportPathUtil.getModelPath(choice),
-				choice);
+				element, ExportImportPathUtil.getModelPath(choice), choice);
 		}
 
 		if (portletDataContext.getBooleanParameter(
 				PollsPortletDataHandler.NAMESPACE, "votes")) {
 
 			for (PollsVote vote : question.getVotes()) {
-				Element voteElement = portletDataContext.getExportDataElement(
-					vote);
+				Element element = portletDataContext.getExportDataElement(vote);
 
 				portletDataContext.addClassedModel(
-					voteElement, ExportImportPathUtil.getModelPath(vote), vote);
+					element, ExportImportPathUtil.getModelPath(vote), vote);
 			}
 		}
 	}

--- a/modules/apps/polls/polls-service/src/main/java/com/liferay/polls/internal/exportimport/portlet/preferences/processor/PollsDisplayExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/polls/polls-service/src/main/java/com/liferay/polls/internal/exportimport/portlet/preferences/processor/PollsDisplayExportImportPortletPreferencesProcessor.java
@@ -23,10 +23,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.polls.constants.PollsConstants;
 import com.liferay.polls.constants.PollsPortletKeys;
 import com.liferay.polls.exception.NoSuchQuestionException;
-import com.liferay.polls.internal.exportimport.data.handler.PollsPortletDataHandler;
-import com.liferay.polls.model.PollsChoice;
 import com.liferay.polls.model.PollsQuestion;
-import com.liferay.polls.model.PollsVote;
 import com.liferay.polls.service.persistence.PollsQuestionUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
@@ -110,20 +107,6 @@ public class PollsDisplayExportImportPortletPreferencesProcessor
 
 		StagedModelDataHandlerUtil.exportReferenceStagedModel(
 			portletDataContext, portletId, question);
-
-		for (PollsChoice choice : question.getChoices()) {
-			StagedModelDataHandlerUtil.exportReferenceStagedModel(
-				portletDataContext, portletId, choice);
-		}
-
-		if (portletDataContext.getBooleanParameter(
-				PollsPortletDataHandler.NAMESPACE, "votes")) {
-
-			for (PollsVote vote : question.getVotes()) {
-				StagedModelDataHandlerUtil.exportReferenceStagedModel(
-					portletDataContext, portletId, vote);
-			}
-		}
 
 		return portletPreferences;
 	}

--- a/util-taglib/src/com/liferay/taglib/ui/InputPermissionsParamsTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/InputPermissionsParamsTag.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.model.RoleConstants;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
+import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.service.RoleLocalServiceUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.JavaConstants;
@@ -143,10 +144,22 @@ public class InputPermissionsParamsTag extends TagSupport {
 			ResourceActionsUtil.getModelResourceGuestDefaultActions(modelName);
 
 		if (layout.isTypeControlPanel()) {
+			long refererPlid = themeDisplay.getRefererPlid();
+
 			Group group = themeDisplay.getScopeGroup();
 
-			if (!group.hasPrivateLayouts() &&
-				guestDefaultActions.contains(ActionKeys.VIEW)) {
+			if (refererPlid > 0) {
+				Layout refererLayout = LayoutLocalServiceUtil.getLayout(
+					refererPlid);
+
+				if (refererLayout.isPublicLayout() &&
+					guestDefaultActions.contains(ActionKeys.VIEW)) {
+
+					return RoleConstants.GUEST;
+				}
+			}
+			else if (!group.hasPrivateLayouts() &&
+					 guestDefaultActions.contains(ActionKeys.VIEW)) {
 
 				return RoleConstants.GUEST;
 			}


### PR DESCRIPTION
The issue is the default View permission of Web Content is not correctly set. Web Content's creation path is set to derive from the Control Panel, so it enters the Control Panel condition in com.liferay.taglib.ui.InputPermissionsParamsTag.getDefaultViewRole(String, ThemeDisplay). If there are private pages, the View permission is set to its default group role. This causes the problem that when a user is to create a Web Content in a public page the default View permission is set to its default group role if the group contained private pages.  

I set the referringPlid from edit_article.jsp to themeDisplay so it can be used to get the layout/page of its reference in InputPermissionsParamsTag.getDefaultViewRole(String, ThemeDisplay). The if block that checks if refererPlid is not equal to 0 determines if the current page was referred to by the Control Panel or another page/portlet (0 means Control Panel). It would enter this block and get the layout of the referred page and check if that page was public or not. If it was a public page, then the pop-up was referenced by a public layout so the default View would be 'anyone'. 

Otherwise, it would follow the original logic. If the user adds a new Web Content through the Control Panel, the referringPlid would be 0 and it would go through the original condition to check if the group contains private layouts and determine the default View permission from there. 

[LPS-91578](https://issues.liferay.com/browse/LPS-91578) 