### PR TITLE
LPS-92048 v7_0_5.UpgradeExpando takes a really long time to complete

### DIFF
--- a/modules/apps/polls/polls-service/src/main/java/com/liferay/polls/internal/exportimport/data/handler/PollsQuestionStagedModelDataHandler.java
+++ b/modules/apps/polls/polls-service/src/main/java/com/liferay/polls/internal/exportimport/data/handler/PollsQuestionStagedModelDataHandler.java
@@ -19,7 +19,9 @@ import com.liferay.exportimport.kernel.lar.ExportImportPathUtil;
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
 import com.liferay.exportimport.kernel.lar.StagedModelDataHandler;
 import com.liferay.exportimport.kernel.lar.StagedModelModifiedDateComparator;
+import com.liferay.polls.model.PollsChoice;
 import com.liferay.polls.model.PollsQuestion;
+import com.liferay.polls.model.PollsVote;
 import com.liferay.polls.service.PollsQuestionLocalService;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -103,6 +105,27 @@ public class PollsQuestionStagedModelDataHandler
 		portletDataContext.addClassedModel(
 			questionElement, ExportImportPathUtil.getModelPath(question),
 			question);
+
+		for (PollsChoice choice : question.getChoices()) {
+			Element choiceElement = portletDataContext.getExportDataElement(
+				choice);
+
+			portletDataContext.addClassedModel(
+				choiceElement, ExportImportPathUtil.getModelPath(choice),
+				choice);
+		}
+
+		if (portletDataContext.getBooleanParameter(
+				PollsPortletDataHandler.NAMESPACE, "votes")) {
+
+			for (PollsVote vote : question.getVotes()) {
+				Element voteElement = portletDataContext.getExportDataElement(
+					vote);
+
+				portletDataContext.addClassedModel(
+					voteElement, ExportImportPathUtil.getModelPath(vote), vote);
+			}
+		}
 	}
 
 	@Override

--- a/modules/apps/polls/polls-service/src/main/java/com/liferay/polls/internal/exportimport/data/handler/PollsQuestionStagedModelDataHandler.java
+++ b/modules/apps/polls/polls-service/src/main/java/com/liferay/polls/internal/exportimport/data/handler/PollsQuestionStagedModelDataHandler.java
@@ -107,20 +107,23 @@ public class PollsQuestionStagedModelDataHandler
 			question);
 
 		for (PollsChoice choice : question.getChoices()) {
-			Element element = portletDataContext.getExportDataElement(choice);
+			Element choiceElement = portletDataContext.getExportDataElement(
+				choice);
 
 			portletDataContext.addClassedModel(
-				element, ExportImportPathUtil.getModelPath(choice), choice);
+				choiceElement, ExportImportPathUtil.getModelPath(choice),
+				choice);
 		}
 
 		if (portletDataContext.getBooleanParameter(
 				PollsPortletDataHandler.NAMESPACE, "votes")) {
 
 			for (PollsVote vote : question.getVotes()) {
-				Element element = portletDataContext.getExportDataElement(vote);
+				Element voteElement = portletDataContext.getExportDataElement(
+					vote);
 
 				portletDataContext.addClassedModel(
-					element, ExportImportPathUtil.getModelPath(vote), vote);
+					voteElement, ExportImportPathUtil.getModelPath(vote), vote);
 			}
 		}
 	}

--- a/modules/apps/polls/polls-service/src/main/java/com/liferay/polls/internal/exportimport/data/handler/PollsQuestionStagedModelDataHandler.java
+++ b/modules/apps/polls/polls-service/src/main/java/com/liferay/polls/internal/exportimport/data/handler/PollsQuestionStagedModelDataHandler.java
@@ -107,23 +107,20 @@ public class PollsQuestionStagedModelDataHandler
 			question);
 
 		for (PollsChoice choice : question.getChoices()) {
-			Element choiceElement = portletDataContext.getExportDataElement(
-				choice);
+			Element element = portletDataContext.getExportDataElement(choice);
 
 			portletDataContext.addClassedModel(
-				choiceElement, ExportImportPathUtil.getModelPath(choice),
-				choice);
+				element, ExportImportPathUtil.getModelPath(choice), choice);
 		}
 
 		if (portletDataContext.getBooleanParameter(
 				PollsPortletDataHandler.NAMESPACE, "votes")) {
 
 			for (PollsVote vote : question.getVotes()) {
-				Element voteElement = portletDataContext.getExportDataElement(
-					vote);
+				Element element = portletDataContext.getExportDataElement(vote);
 
 				portletDataContext.addClassedModel(
-					voteElement, ExportImportPathUtil.getModelPath(vote), vote);
+					element, ExportImportPathUtil.getModelPath(vote), vote);
 			}
 		}
 	}

--- a/modules/apps/polls/polls-service/src/main/java/com/liferay/polls/internal/exportimport/portlet/preferences/processor/PollsDisplayExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/polls/polls-service/src/main/java/com/liferay/polls/internal/exportimport/portlet/preferences/processor/PollsDisplayExportImportPortletPreferencesProcessor.java
@@ -23,10 +23,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.polls.constants.PollsConstants;
 import com.liferay.polls.constants.PollsPortletKeys;
 import com.liferay.polls.exception.NoSuchQuestionException;
-import com.liferay.polls.internal.exportimport.data.handler.PollsPortletDataHandler;
-import com.liferay.polls.model.PollsChoice;
 import com.liferay.polls.model.PollsQuestion;
-import com.liferay.polls.model.PollsVote;
 import com.liferay.polls.service.persistence.PollsQuestionUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
@@ -110,20 +107,6 @@ public class PollsDisplayExportImportPortletPreferencesProcessor
 
 		StagedModelDataHandlerUtil.exportReferenceStagedModel(
 			portletDataContext, portletId, question);
-
-		for (PollsChoice choice : question.getChoices()) {
-			StagedModelDataHandlerUtil.exportReferenceStagedModel(
-				portletDataContext, portletId, choice);
-		}
-
-		if (portletDataContext.getBooleanParameter(
-				PollsPortletDataHandler.NAMESPACE, "votes")) {
-
-			for (PollsVote vote : question.getVotes()) {
-				StagedModelDataHandlerUtil.exportReferenceStagedModel(
-					portletDataContext, portletId, vote);
-			}
-		}
 
 		return portletPreferences;
 	}

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeAsset.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeAsset.java
@@ -16,6 +16,8 @@ package com.liferay.portal.upgrade.v7_0_0;
 
 import com.liferay.asset.kernel.model.AssetCategoryConstants;
 import com.liferay.document.library.kernel.model.DLFileEntryConstants;
+import com.liferay.portal.kernel.dao.db.DBType;
+import com.liferay.portal.kernel.dao.db.DBTypeToSQLMap;
 import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -53,7 +55,21 @@ public class UpgradeAsset extends UpgradeProcess {
 			sb.append("DLFileVersion) and classPK not in (select fileEntryId ");
 			sb.append("from DLFileEntry)");
 
-			runSQL(sb.toString());
+			DBTypeToSQLMap dbTypeToSQLMap = new DBTypeToSQLMap(sb.toString());
+
+			sb = new StringBundler(5);
+
+			sb.append("delete from AssetEntry where classNameId = ");
+			sb.append(classNameId);
+			sb.append(" and not exists (select null from DLFileVersion where ");
+			sb.append("fileVersionId = classPK) and not exists (select null ");
+			sb.append("from DLFileEntry where fileEntryId = classPK)");
+
+			String sql = sb.toString();
+
+			dbTypeToSQLMap.add(DBType.POSTGRESQL, sql);
+
+			runSQL(dbTypeToSQLMap);
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_5/UpgradeExpando.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_5/UpgradeExpando.java
@@ -14,6 +14,8 @@
 
 package com.liferay.portal.upgrade.v7_0_5;
 
+import com.liferay.portal.kernel.dao.db.DBType;
+import com.liferay.portal.kernel.dao.db.DBTypeToSQLMap;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 
 /**
@@ -22,9 +24,23 @@ import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 public class UpgradeExpando extends UpgradeProcess {
 
 	protected void deleteOrphanExpandoRow() throws Exception {
-		runSQL(
-			"delete from ExpandoRow where rowId_ not in (select rowId_ from " +
-				"ExpandoValue)");
+		StringBuilder sb = new StringBuilder(2);
+
+		sb.append("delete from ExpandoRow where rowId_ not in (select ");
+		sb.append("rowId_ from ExpandoValue)");
+
+		DBTypeToSQLMap dbTypeToSQLMap = new DBTypeToSQLMap(sb.toString());
+
+		sb = new StringBuilder(2);
+
+		sb.append("delete from ExpandoRow er where not exists (select null ");
+		sb.append("from ExpandoValue ev where ev.rowId_ = er.rowId_)");
+
+		String sql = sb.toString();
+
+		dbTypeToSQLMap.add(DBType.POSTGRESQL, sql);
+
+		runSQL(dbTypeToSQLMap);
 	}
 
 	@Override


### PR DESCRIPTION
The issue is that database upgrades take a longer time to complete due to the use of the clause NOT IN, since it needs to look for the values twice. This degrades the query performance. NOT EXISTS looks at the missing values once, making this query ore efficient.

Taking into account Alberto's [comment](https://issues.liferay.com/browse/LPP-33245?focusedCommentId=1735725&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-1735725), I have changed the query in the cases that Postrges database is being used. 

The DBTypeToSQLMap is the framework used to apply the newly converted string to Postgres databases. The original query string will be applied when the database is not Postgres.

[LPS-92048](https://issues.liferay.com/browse/LPS-92048)