### PR TITLE
LPS-92354 Template JS is stripped with a syntax error

### DIFF
--- a/modules/apps/frontend-js/frontend-js-minifier/src/main/java/com/frontend/js/minifier/GoogleJavaScriptMinifier.java
+++ b/modules/apps/frontend-js/frontend-js-minifier/src/main/java/com/frontend/js/minifier/GoogleJavaScriptMinifier.java
@@ -70,7 +70,13 @@ public class GoogleJavaScriptMinifier implements JavaScriptMinifier {
 				SourceFile.fromCode("extern", StringPool.BLANK), sourceFile,
 				compilerOptions);
 
-			return compiler.toSource();
+			String compiledString = compiler.toSource();
+
+			if (compiledString.isEmpty()) {
+				return content;
+			}
+
+			return compiledString;
 		}
 		finally {
 			if (_clearThreadTraceMethod != null) {


### PR DESCRIPTION
This issue occurs when the script is being minified and there is a syntax error within the script. The minifier cannot minify the script with a syntax error so it returns an empty string. This means when the developer checks in the dev tools there is no associated code within the script tag, also the dev tool's console does not display the error unless its the first time the content is being rendered. 

The fix is to check if the compiler had stripped the script of its content. If the compiler returns an empty string, the function will return its content because it had either stripped the script or the script was already empty. Otherwise, it would return the compiled string. 
 
https://issues.liferay.com/browse/LPS-92354