### PR TITLE
LPS-93227 Add 'X' to alert danger banner

### DIFF
--- a/portal-web/docroot/html/taglib/ui/error/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/error/page.jsp
@@ -27,7 +27,15 @@ String rowBreak = (String)request.getAttribute("liferay-ui:error:rowBreak");
 
 <c:choose>
 	<c:when test="<%= embed %>">
-		<div class="alert alert-<%= alertStyle %>" role="alert">
+		<div class="alert alert-<%= alertStyle %> alert-dismissible" role="alert">
+			<button aria-label="<%= LanguageUtil.get(request, "close") %>" class="close" data-dismiss="alert" type="button">
+				<svg aria-hidden="true" class="icon-monospaced lexicon-icon lexicon-icon-times">
+					<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/lexicon/icons.svg#times"></use>
+				</svg>
+
+				<span class="sr-only"><%= LanguageUtil.get(request, "close") %></span>
+			</button>
+
 			<span class="alert-indicator">
 				<svg aria-hidden="true" class="lexicon-icon lexicon-icon-<%= alertIcon %>">
 					<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/lexicon/icons.svg#<%= alertIcon %>"></use>


### PR DESCRIPTION
This fix is a suggestion from [andrashimerliferay](https://github.com/moltam89/liferay-portal/pull/482#issuecomment-474798374). It is related to [LPS-89294](https://issues.liferay.com/browse/LPS-89294) where the close button will be added to the banners within the staging tab when there is no connection to the live server. 

https://issues.liferay.com/browse/LPS-93227