### PR TITLE
LPS-93332 Remove final from login.events.post and login.events.pre

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -1663,10 +1663,10 @@ public class PropsValues {
 	public static final String LOGIN_EMAIL_FROM_NAME = PropsUtil.get(
 		PropsKeys.LOGIN_EMAIL_FROM_NAME);
 
-	public static final String[] LOGIN_EVENTS_POST = PropsUtil.getArray(
+	public static String[] LOGIN_EVENTS_POST = PropsUtil.getArray(
 		PropsKeys.LOGIN_EVENTS_POST);
 
-	public static final String[] LOGIN_EVENTS_PRE = PropsUtil.getArray(
+	public static String[] LOGIN_EVENTS_PRE = PropsUtil.getArray(
 		PropsKeys.LOGIN_EVENTS_PRE);
 
 	public static String[] LOGIN_FORM_NAVIGATION_POST = PropsUtil.getArray(


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-93332

In [LPS-78163](https://issues.liferay.com/browse/LPS-78163), `login.events.post` and `login.events.pre` was introduced as variables that can be modified in [HookHotDeployListener](https://github.com/liferay/liferay-portal/blob/7.1.0-ga1/portal-impl/src/com/liferay/portal/deploy/hot/HookHotDeployListener.java#L2379-L2408).  In this case, we must get rid of `final` in order to allow changes in [resetPortalPropertiesStringArray](https://github.com/liferay/liferay-portal/blob/master/portal-impl/src/com/liferay/portal/deploy/hot/HookHotDeployListener.java#L2133-L2160).
Let me know if there are any questions or comments about this.
Thank you.