### PR TITLE
LPS-89861 Check focus before displaying error message

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/checkbox-multiple/checkbox_multiple_field.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/checkbox-multiple/checkbox_multiple_field.js
@@ -107,6 +107,14 @@ AUI.add(
 						CheckboxMultipleField.superclass.showErrorMessage.apply(instance, arguments);
 					},
 
+					showPendingErrorMessage: function() {
+						var instance = this;
+
+						if (!instance.hasFocus()) {
+							instance.showErrorMessage();
+						}
+					},
+
 					_getOptions: function(options) {
 						var instance = this;
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/radio/radio_field.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/radio/radio_field.js
@@ -107,6 +107,14 @@ AUI.add(
 						var formGroup = container.one('.form-group');
 
 						formGroup.insert(container.one('.form-feedback-indicator'), 'after');
+					},
+
+					showPendingErrorMessage: function() {
+						var instance = this;
+
+						if (!instance.hasFocus()) {
+							instance.showErrorMessage();
+						}
 					}
 				}
 			}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/field_validation_support.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/field_validation_support.js
@@ -64,6 +64,8 @@ AUI.add(
 
 				var evaluator = instance.get('evaluator');
 
+				var type = instance.get('type');
+
 				if (evaluator && evaluator.isEvaluating()) {
 					evaluator.onceAfter(
 						'evaluationEnded',
@@ -73,6 +75,11 @@ AUI.add(
 							}
 						}
 					);
+				}
+				else if (type === 'checkbox_multiple' || type === 'radio') {
+					setTimeout(function() {
+						instance.showPendingErrorMessage();
+					}, 100);
 				}
 				else {
 					instance.showErrorMessage();


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-89861

When a multiple selection checkbox has focus and a different checkbox is selected, an error message will display for a brief time and disappear. This is due to the checkboxes handled as individual elements and the focus is granted separately. In order to fix this, there needs to be a check whether the current element being selected is a checkbox or radio element, and then check to see if they currently have focus. If they do have focus, then no error message should appear.
Let me know if there are any question or comments about this.
Thank you.