### PR TITLE
LPS-94556 Merge Props_Key_Events and prevent change

### DIFF
--- a/portal-impl/src/com/liferay/portal/deploy/hot/HookHotDeployListener.java
+++ b/portal-impl/src/com/liferay/portal/deploy/hot/HookHotDeployListener.java
@@ -2207,7 +2207,9 @@ public class HookHotDeployListener
 			PropsUtil.addProperties(properties);
 		}
 
-		field.set(null, value);
+		if (!_propsKeysEvents.contains(key)) {
+			field.set(null, value);
+		}
 	}
 
 	private void _initServices(
@@ -2302,12 +2304,14 @@ public class HookHotDeployListener
 		"journal.article.form.update", "layout.form.add", "layout.form.update",
 		"layout.set.form.update", "layout.static.portlets.all",
 		"login.events.post", "login.events.pre", "login.form.navigation.post",
-		"login.form.navigation.pre", "organizations.form.add.identification",
-		"organizations.form.add.main", "organizations.form.add.miscellaneous",
+		"login.form.navigation.pre", "logout.events.pre", "logout.events.post",
+		"organizations.form.add.identification", "organizations.form.add.main",
+		"organizations.form.add.miscellaneous",
 		"portlet.add.default.resource.check.whitelist",
 		"portlet.add.default.resource.check.whitelist.actions",
 		"portlet.interrupted.request.whitelist",
 		"portlet.interrupted.request.whitelist.actions",
+		"servlet.service.events.post", "servlet.service.events.pre",
 		"session.phishing.protected.attributes", "sites.form.add.advanced",
 		"sites.form.add.main", "sites.form.add.miscellaneous",
 		"sites.form.add.seo", "sites.form.update.advanced",


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-94556

Creating a hook for login.events.post will result in a ClassNotFoundException. This is due to the hook property being added to the [field](https://github.com/liferay/liferay-portal/blob/master/portal-impl/src/com/liferay/portal/deploy/hot/HookHotDeployListener.java#L2210) and trying to process the Class. This is not needed since the previous property does the processing of the hook [here.](https://github.com/liferay/liferay-portal/blob/7.1.1-ga2/portal-impl/src/com/liferay/portal/deploy/hot/HookHotDeployListener.java#L834-L844)

A solution for this is to prevent the properties from being updated in the field. Without the hook property, the hook will run correctly without any issues. I also added the reset of the `_PROPS_KEYS_EVENTS` into the `_PROPS_VALUES_MERGE_STRING_ARRAY` so that this issue will not occur for these hooks. Please let me know if there are any questions or comments about this.

Thank you.