### PR TITLE
LPS-94945 Remove required validator from template

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/com/liferay/dynamic/data/mapping/dependencies/ddm/image.ftl
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/com/liferay/dynamic/data/mapping/dependencies/ddm/image.ftl
@@ -54,11 +54,7 @@
 			name=namespacedFieldName
 			type="hidden"
 			value=fieldRawValue
-		>
-			<#if required>
-				<@liferay_aui.validator name="required" />
-			</#if>
-		</@>
+		/>
 
 		<div class="button-holder">
 			<@liferay_aui.button


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-94945

The issue is that the required message is being displayed two times. Since it is being called twice, a solution is to remove the required validator in the `image.ftl`. This will then only display one error message. Let me know if there are any questions or comments about this.

Thank you.
