### PR TITLE
LPS-94798 Remove the adjustment of align point

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/menu.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/menu.js
@@ -348,8 +348,6 @@ AUI.add(
 
 					var modalMask = false;
 
-					align.points = instance._getAlignPoints(cssClass);
-
 					menu.addClass('lfr-icon-menu-open');
 
 					if (Util.isPhone() || Util.isTablet()) {


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-94798
https://issues.liferay.com/browse/LPS-94822
This pull request fixes these two issues.

The box of the pagination is not correctly aligned with the button. A solution I found was to remove the adjustment of `align.points`. The alignment of the cssClass `dropdown-toggle direction-down max-display-items-15 btn btn-default` is the wrong alignment. Without the change of alignment, the box aligns correctly. I have checked other pagination buttons and it either fixes the issue or does not change any the buttons. If there are any questions please let me know if there are any questions.

Thank you.