### PR TITLE
LPS-95604

### DIFF
--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/simple_menu.js
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/simple_menu.js
@@ -168,32 +168,34 @@ AUI.add(
 					_positionMenu: function() {
 						var instance = this;
 
-						var Util = Liferay.Util;
+						if (instance.items.size() > 0) {
+							var Util = Liferay.Util;
 
-						var align = {
-							node: instance.get('alignNode'),
-							points: DEFAULT_ALIGN_POINTS
-						};
+							var align = {
+								node: instance.get('alignNode'),
+								points: DEFAULT_ALIGN_POINTS
+							};
 
-						var centered = false;
-						var modal = false;
-						var width = 222;
+							var centered = false;
+							var modal = false;
+							var width = 222;
 
-						if (Util.isPhone() || Util.isTablet()) {
-							align = null;
-							centered = true;
-							modal = true;
-							width = '90%';
-						}
-
-						instance.setAttrs(
-							{
-								align: align,
-								centered: centered,
-								modal: modal,
-								width: width
+							if (Util.isPhone() || Util.isTablet()) {
+								align = null;
+								centered = true;
+								modal = true;
+								width = '90%';
 							}
-						);
+
+							instance.setAttrs(
+								{
+									align: align,
+									centered: centered,
+									modal: modal,
+									width: width
+								}
+							);
+						}
 					},
 
 					_renderItems: function(items) {


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-95604

When the Calendar portlet only displays the scheduler, the menus' modal for the calendar list container will be adjusted and moved when the screen is resized. We can check whether there are any items for the menu before making any adjustments. If there are no items, we will not adjust the modal. I tested that this works with and without the scheduler. Let me know if there are any questions or comments about this.

Thank you.