### PR TITLE
LPS-95838 Remove unused field contexts

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/form_context_support.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/form_context_support.js
@@ -191,6 +191,8 @@ AUI.add(
 									}
 								}
 							);
+
+							instance._removeFieldContexts(columnFieldContexts, repeatedSiblings);
 						}
 					}
 				);
@@ -214,6 +216,54 @@ AUI.add(
 				visitor.set('pages', context.pages);
 
 				instance.set('fields', instance._createFieldsFromContext(context));
+			},
+
+			/**
+			 * This method removes fields from columnFieldContexts that are no
+			 * longer being used. It checks if the field is in repeatedSiblings
+			 * in order to decide to remove it or not.
+			 *
+			 * @param columnFieldContexts
+			 * @param repeatedSiblings
+			 * @private
+			 */
+			_removeFieldContexts: function(columnFieldContexts, repeatedSiblings) {
+				var removeContext = [];
+				var repeatedContext = [];
+
+				//Get the context of repeatedSiblings and place them in repeatedContext
+				repeatedSiblings.forEach(
+					function(context) {
+						repeatedContext.push(context.get('context'));
+					}
+				);
+
+				//Loop through columnFieldContexts and try to find the same field in repeatedContext.
+				columnFieldContexts.forEach(function(columnFieldContext) {
+					var foundFieldContext = AArray.find(
+						repeatedContext,
+						function(repeatedContext) {
+							if (columnFieldContext.fieldName === repeatedContext.fieldName &&
+								columnFieldContext.instanceId === repeatedContext.instanceId) {
+
+								return true;
+							}
+
+							return false;
+						}
+					);
+
+					//If the field in columnFieldContexts cannot be found in repeatedContext,
+					//place the field in the removeContext array.
+					if (!foundFieldContext) {
+						removeContext.push(columnFieldContext);
+					}
+				});
+
+				//Remove the fields from columnFieldContexts
+				for (var i in removeContext) {
+					columnFieldContexts.splice(columnFieldContexts.indexOf(removeContext[i]), 1);
+				};
 			},
 
 			_scheduleFieldDisposal: function(field) {


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-95838

When a form is being filled out and autosaved, if a repeatable field is removed it will not register in the autosave and will reappear after a refresh. This is due to not checking `columnFieldContexts` and removing the unused field. A solution is to check which fields are in `repeatedSiblings` and remove the unused fields in `columnFieldContexts`. Let me know if there are any questions or comments about this.

Thank you.